### PR TITLE
Add test to check OID repr returns correct results

### DIFF
--- a/gssapi/tests/test_raw.py
+++ b/gssapi/tests/test_raw.py
@@ -730,3 +730,23 @@ class TestWrapUnwrap(_GSSAPIKerberosTestCase):
         unwrapped_message.should_be_a(bytes)
         unwrapped_message.shouldnt_be_empty()
         unwrapped_message.should_be(b'test message')
+
+
+TEST_OIDS = {'SPNEGO': {'bytes': '\053\006\001\005\005\002',
+                        'string': '<OID 1.3.6.1.5.5.2>'},
+             'KRB5': {'bytes': '\052\206\110\206\367\022\001\002\002',
+                      'string': '<OID 1.2.840.113554.1.2.2>'},
+             'KRB5_OLD': {'bytes': '\053\005\001\005\002',
+                          'string': '<OID 1.3.5.1.5.2>'},
+             'KRB5_WRONG': {'bytes': '\052\206\110\202\367\022\001\002\002',
+                            'string': '<OID 1.2.840.48018.1.2.2>'},
+             'IAKERB': {'bytes': '\053\006\001\005\002\005',
+                        'string': '<OID 1.3.6.1.5.2.5>'}}
+
+
+class TestOIDTransforms(unittest.TestCase):
+    def test_decode_from_bytes(self):
+        for oid in TEST_OIDS.values():
+            o = gb.OID(elements=oid['bytes'])
+            text = repr(o)
+            text.should_be(oid['string'])


### PR DESCRIPTION
Uses known OIDs as test vectors.

Signed-off-by: Simo Sorce simo@redhat.com
