### PR TITLE
Clean up "Not Yet Implemented" tests

### DIFF
--- a/gssapi/creds.py
+++ b/gssapi/creds.py
@@ -170,8 +170,8 @@ class Credentials(rcreds.Creds):
                 raise NotImplementedError("Your GSSAPI implementation does "
                                           "not have support for RFC 5588")
 
-            return rcred_cred_store.store_cred(self, usage, mech,
-                                               overwrite, set_default)
+            return rcred_rfc5588.store_cred(self, usage, mech,
+                                            overwrite, set_default)
         else:
             if rcred_cred_store is None:
                 raise NotImplementedError("Your GSSAPI implementation does "
@@ -332,6 +332,7 @@ class Credentials(rcreds.Creds):
                 raise NotImplementedError("Your GSSAPI implementation does "
                                           "not have support for manipulating "
                                           "credential stores")
+            store = _encode_dict(store)
 
             res = rcred_cred_store.add_cred_from(store, self, desired_name,
                                                  desired_mech, usage,

--- a/gssapi/raw/sec_contexts.pyx
+++ b/gssapi/raw/sec_contexts.pyx
@@ -310,7 +310,7 @@ def accept_sec_context(input_token not None, Creds acceptor_cred=None,
         free(bdng)
 
     cdef Name on = Name()
-    cdef Creds oc = Creds()
+    cdef Creds oc = None
     cdef OID py_mech_type
     if maj_stat == GSS_S_COMPLETE or maj_stat == GSS_S_CONTINUE_NEEDED:
         if output_ttl == GSS_C_INDEFINITE:
@@ -319,7 +319,11 @@ def accept_sec_context(input_token not None, Creds acceptor_cred=None,
             output_ttl_py = output_ttl
 
         on.raw_name = initiator_name
-        oc.raw_creds = delegated_cred
+
+        if delegated_cred is not NULL:
+            oc = Creds()
+            oc.raw_creds = delegated_cred
+
         if mech_type is not NULL:
             py_mech_type = OID()
             py_mech_type.raw_oid = mech_type[0]


### PR DESCRIPTION
This commit adds in tests for places that were previously
marked as "Not Yet Implemented".  Additionally, a couple
of mistypes were discovered and fixed in heretofore untested
methods.

Close #22
