### PR TITLE
Set several default initial args to `None` for convenience

### DIFF
--- a/gssapi/raw/creds.pyx
+++ b/gssapi/raw/creds.pyx
@@ -80,7 +80,7 @@ cdef class Creds:
             self.raw_creds = NULL
 
 
-def acquire_cred(Name name, lifetime=None, mechs=None, usage='both'):
+def acquire_cred(Name name=None, lifetime=None, mechs=None, usage='both'):
     """
     Get GSSAPI credentials for the given name and mechanisms.
 

--- a/gssapi/raw/ext_cred_store.pyx
+++ b/gssapi/raw/ext_cred_store.pyx
@@ -92,9 +92,7 @@ cdef void c_free_key_value_set(gss_key_value_set_desc *kvset):
     free(kvset)
 
 
-# TODO(directxman12): some of these probably need a "not null",
-#                     but that's not clear from the wiki page
-def acquire_cred_from(dict store, Name name, lifetime=None,
+def acquire_cred_from(dict store=None, Name name=None, lifetime=None,
                       mechs=None, usage='both'):
     """Acquire credentials from the given store
 

--- a/gssapi/raw/names.pyx
+++ b/gssapi/raw/names.pyx
@@ -163,7 +163,7 @@ def display_name(Name name not None, name_type=True):
         raise GSSError(maj_stat, min_stat)
 
 
-def compare_name(Name name1, Name name2):
+def compare_name(Name name1=None, Name name2=None):
     """
     Check two GSSAPI names to see if they are the same.
 


### PR DESCRIPTION
This should be all occurrences in the low-level api, and so this should close #29.

More defaults can be set, but:

1. That would change the API since default arguments follow positionals, so this could not be for 1.1.0.
2. The convenience gained in these changes appears minimal at the present time.
3. This introduces further deviation in the low-level API from the C API, which makes it probably irrelevant.