### PR TITLE
Set hostname in travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ python:
   - "3.4"
 
 install:
+  - "sudo sed -i '1i 127.0.0.1 test.box' /etc/hosts"
+  - "sudo hostname test.box"
   - "sudo apt-add-repository -y ppa:sssd/updates "
   - "sudo apt-get update -q"
   - "DEBIAN_FRONTEND=noninteractive sudo apt-get install -qq krb5-user krb5-kdc krb5-admin-server"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
   - "sudo hostname test.box"
   - "sudo apt-add-repository -y ppa:sssd/updates "
   - "sudo apt-get update -q"
-  - "DEBIAN_FRONTEND=noninteractive sudo apt-get install -qq krb5-user krb5-kdc krb5-admin-server"
+  - "DEBIAN_FRONTEND=noninteractive sudo apt-get install -qq krb5-user krb5-kdc krb5-admin-server libkrb5-dev krb5-multidev"
   - "pip install --install-option='--no-cython-compile' cython"
   - "pip install -r test-requirements.txt"
 


### PR DESCRIPTION
Setting the hostname should remove errors when attempting to establish a security context.

Additionally, robustify the installation of components from sssd in case we encounter version mismatch problems in the future.