### PR TITLE
Use GSS.framework on Mac OS X

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include *.txt
 recursive-include docs *.txt
 recursive-include gssapi *.pxd
 recursive-include gssapi *.c
+recursive-include gssapi *.h

--- a/gssapi/raw/creds.pyx
+++ b/gssapi/raw/creds.pyx
@@ -13,7 +13,7 @@ from gssapi.raw.named_tuples import AcquireCredResult, AddCredResult
 from gssapi.raw.named_tuples import InquireCredResult, InquireCredByMechResult
 
 
-cdef extern from "gssapi.h":
+cdef extern from "python_gssapi.h":
     OM_uint32 gss_acquire_cred(OM_uint32 *min_stat,
                                const gss_name_t name,
                                OM_uint32 ttl,

--- a/gssapi/raw/cython_types.pxd
+++ b/gssapi/raw/cython_types.pxd
@@ -1,7 +1,7 @@
 from libc.stdint cimport uint32_t
 
 
-cdef extern from "gssapi.h":
+cdef extern from "python_gssapi.h":
     # basic types
     ctypedef uint32_t OM_uint32
 

--- a/gssapi/raw/exceptions.pyx
+++ b/gssapi/raw/exceptions.pyx
@@ -5,7 +5,7 @@ from gssapi.raw.misc import GSSError
 """Specific exceptions for GSSAPI errors"""
 
 
-cdef extern from "gssapi.h":
+cdef extern from "python_gssapi.h":
     # calling errors
     OM_uint32 GSS_S_CALL_INACCESSIBLE_READ
     OM_uint32 GSS_S_CALL_INACCESSIBLE_WRITE

--- a/gssapi/raw/ext_cred_imp_exp.pyx
+++ b/gssapi/raw/ext_cred_imp_exp.pyx
@@ -12,7 +12,7 @@ from gssapi.raw.misc import GSSError
 from gssapi.raw.named_tuples import AcquireCredResult, AddCredResult
 
 
-cdef extern from "gssapi/gssapi_ext.h":
+cdef extern from "python_gssapi_ext.h":
     OM_uint32 gss_export_cred(OM_uint32 *min_stat, gss_cred_id_t cred_handle,
                               gss_buffer_t token) nogil
 

--- a/gssapi/raw/ext_cred_store.pyx
+++ b/gssapi/raw/ext_cred_store.pyx
@@ -18,7 +18,7 @@ from gssapi.raw.named_tuples import StoreCredResult
 from gssapi.raw.misc import GSSError
 
 
-cdef extern from "gssapi/gssapi_ext.h":
+cdef extern from "python_gssapi_ext.h":
     ctypedef struct gss_key_value_element_desc:
         const char *key
         const char *value

--- a/gssapi/raw/ext_password.pyx
+++ b/gssapi/raw/ext_password.pyx
@@ -15,7 +15,7 @@ from gssapi.raw.names cimport Name
 from gssapi.raw.misc import GSSError
 from gssapi.raw.named_tuples import AcquireCredResult
 
-cdef extern from "gssapi/gssapi_ext.h":
+cdef extern from "python_gssapi_ext.h":
     OM_uint32 gss_acquire_cred_with_password(OM_uint32 *min_stat,
                                              const gss_name_t desired_name,
                                              const gss_buffer_t password,

--- a/gssapi/raw/ext_password_add.pyx
+++ b/gssapi/raw/ext_password_add.pyx
@@ -16,7 +16,7 @@ from gssapi.raw.oids cimport OID
 from gssapi.raw.misc import GSSError
 from gssapi.raw.named_tuples import AddCredResult
 
-cdef extern from "gssapi/gssapi_ext.h":
+cdef extern from "python_gssapi_ext.h":
     OM_uint32 gss_add_cred_with_password(OM_uint32 *min_stat,
                                          const gss_cred_id_t input_cred_handle,
                                          const gss_name_t desired_name,

--- a/gssapi/raw/ext_rfc5588.pyx
+++ b/gssapi/raw/ext_rfc5588.pyx
@@ -11,7 +11,7 @@ from gssapi.raw.cython_converters cimport c_c_ttl_to_py, c_py_ttl_to_c
 from gssapi.raw.named_tuples import StoreCredResult
 from gssapi.raw.misc import GSSError
 
-cdef extern from "gssapi.h":
+cdef extern from "python_gssapi.h":
     OM_uint32 gss_store_cred(OM_uint32 *min_stat,
                              gss_cred_id_t input_creds,
                              gss_cred_usage_t cred_usage,

--- a/gssapi/raw/ext_s4u.pyx
+++ b/gssapi/raw/ext_s4u.pyx
@@ -12,7 +12,7 @@ from gssapi.raw.misc import GSSError
 from gssapi.raw.named_tuples import AcquireCredResult, AddCredResult
 
 
-cdef extern from "gssapi/gssapi_ext.h":
+cdef extern from "python_gssapi_ext.h":
     OM_uint32 gss_acquire_cred_impersonate_name(OM_uint32 *min_stat,
                                                 const gss_cred_id_t imp_creds,
                                                 const gss_name_t name,

--- a/gssapi/raw/mech_krb5.pyx
+++ b/gssapi/raw/mech_krb5.pyx
@@ -13,7 +13,7 @@ and MechType.
 """
 
 
-cdef extern from "gssapi/gssapi_krb5.h":
+cdef extern from "python_gssapi_krb5.h":
     gss_OID gss_mech_krb5
     gss_OID GSS_KRB5_NT_PRINCIPAL_NAME
 

--- a/gssapi/raw/message.pyx
+++ b/gssapi/raw/message.pyx
@@ -7,7 +7,7 @@ from gssapi.raw.misc import GSSError
 from gssapi.raw.named_tuples import VerifyMICResult, WrapResult, UnwrapResult
 
 
-cdef extern from "gssapi.h":
+cdef extern from "python_gssapi.h":
     OM_uint32 gss_get_mic(OM_uint32 *min_stat,
                           const gss_ctx_id_t context,
                           gss_qop_t qop,

--- a/gssapi/raw/misc.pyx
+++ b/gssapi/raw/misc.pyx
@@ -12,7 +12,7 @@ from gssapi.raw.oids cimport OID
 from gssapi.raw.types import MechType
 
 
-cdef extern from "gssapi.h":
+cdef extern from "python_gssapi.h":
     OM_uint32 gss_display_status(OM_uint32 *minor_status,
                                  OM_uint32 status_value,
                                  int status_type,

--- a/gssapi/raw/names.pyx
+++ b/gssapi/raw/names.pyx
@@ -7,7 +7,7 @@ from gssapi.raw.misc import GSSError
 from gssapi.raw.named_tuples import DisplayNameResult
 
 
-cdef extern from "gssapi.h":
+cdef extern from "python_gssapi.h":
     OM_uint32 gss_import_name(OM_uint32 *min_stat,
                               const gss_buffer_t input_buffer,
                               const gss_OID name_type,

--- a/gssapi/raw/python_gssapi.h
+++ b/gssapi/raw/python_gssapi.h
@@ -1,0 +1,5 @@
+#ifdef OSX_HAS_GSS_FRAMEWORK
+#include <GSS/GSS.h>
+#else
+#include <gssapi/gssapi.h>
+#endif

--- a/gssapi/raw/python_gssapi_ext.h
+++ b/gssapi/raw/python_gssapi_ext.h
@@ -1,0 +1,9 @@
+#ifdef OSX_HAS_GSS_FRAMEWORK
+#include <GSS/GSS.h>
+#else
+#ifdef HAS_GSSAPI_EXT_H
+#include <gssapi/gssapi_ext.h>
+#else
+#include <gssapi/gssapi.h>
+#endif
+#endif

--- a/gssapi/raw/python_gssapi_krb5.h
+++ b/gssapi/raw/python_gssapi_krb5.h
@@ -1,0 +1,5 @@
+#ifdef OSX_HAS_GSS_FRAMEWORK
+#include <GSS/gssapi_krb5.h>
+#else
+#include <gssapi/gssapi_krb5.h>
+#endif

--- a/gssapi/raw/sec_contexts.pyx
+++ b/gssapi/raw/sec_contexts.pyx
@@ -16,7 +16,7 @@ from gssapi.raw.named_tuples import InitSecContextResult
 from gssapi.raw.named_tuples import InquireContextResult
 
 
-cdef extern from "gssapi.h":
+cdef extern from "python_gssapi.h":
     OM_uint32 gss_init_sec_context(OM_uint32 *min_stat,
                                    const gss_cred_id_t initiator_creds,
                                    gss_ctx_id_t *context,


### PR DESCRIPTION
On Mac OS X, Apple wants us to use the GSS.framework to compile against GSSAPI, and `#include <GSS/...>` instead of `<gssapi/gssapi.h>`. With this change we can choose headers to link against at compile time, without changing our source and header files.