### PR TITLE
Low-level: allow mutating input creds in add_cred

### DIFF
--- a/gssapi/tests/test_raw.py
+++ b/gssapi/tests/test_raw.py
@@ -402,6 +402,9 @@ class TestBaseUtilities(_GSSAPIKerberosTestCase):
 
         new_creds.should_be_a(gb.Creds)
 
+    # NB(sross): we skip testing add_cred with mutate for the same reasons
+    #            that testing add_cred in the high-level API is skipped
+
     def test_inquire_creds(self):
         name = gb.import_name(SERVICE_PRINCIPAL,
                               gb.NameType.kerberos_principal)


### PR DESCRIPTION
This commit adds an optional parameter to `add_cred`,
`mutate_input`, which allows `add_cred` to either
create a new set of credentials containing the input
credentials and the new credentials (False) or
to just modify the input credentials, adding the new
credentials directly to them (True).  Previously, only
the former was possible.

Closes #18.