### PR TITLE
Travis support for 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,9 @@ python:
   - "3.4"
 
 env:
-  - KRB5_PPAS="sssd/updates"
-  - KRB5_PPAS="rharwood/krb5-1.13 sssd/updates"
+  - KRB5_PPAS="" # 1.10
+  - KRB5_PPAS="sssd/updates" # 1.12
+  - KRB5_PPAS="rharwood/krb5-1.13 sssd/updates" # 1.13
 
 install:
   - "sudo sed -i '1i 127.0.0.1 test.box' /etc/hosts"

--- a/gssapi/tests/_utils.py
+++ b/gssapi/tests/_utils.py
@@ -1,5 +1,18 @@
 from gssapi._utils import import_gssapi_extension
 
+try:
+    import commands
+    get_output = commands.getoutput
+except ImportError:
+    import subprocess
+
+    def _get_output(*args, **kwargs):
+        res = subprocess.check_output(*args, shell=True, **kwargs)
+        decoded = res.decode('utf-8')
+        return decoded.strip()
+
+    get_output = _get_output
+
 
 def _extension_test(extension_name, extension_text):
     def make_ext_test(func):
@@ -10,6 +23,27 @@ def _extension_test(extension_name, extension_text):
             else:
                 func(self, *args, **kwargs)
 
+        return ext_test
+
+    return make_ext_test
+
+
+_KRB_VERSION = None
+
+
+def _minversion_test(target_version, problem):
+    global _KRB_VERSION
+    if _KRB_VERSION is None:
+        _KRB_VERSION = get_output("krb5-config --version")
+        _KRB_VERSION = _KRB_VERSION.split(' ')[-1].split('.')
+
+    def make_ext_test(func):
+        def ext_test(self, *args, **kwargs):
+            if _KRB_VERSION < target_version.split('.'):
+                self.skipTest("Your GSSAPI (version %s) is known to have "
+                              "problems with %s" % (_KRB_VERSION, problem))
+            else:
+                func(self, *args, **kwargs)
         return ext_test
 
     return make_ext_test

--- a/gssapi/tests/test_high_level.py
+++ b/gssapi/tests/test_high_level.py
@@ -14,7 +14,7 @@ from gssapi import sec_contexts as gssctx
 from gssapi import raw as gb
 from gssapi import _utils as gssutils
 from gssapi import exceptions as excs
-from gssapi.tests._utils import _extension_test
+from gssapi.tests._utils import _extension_test, _minversion_test
 from gssapi.tests import k5test as kt
 
 
@@ -656,6 +656,7 @@ class SecurityContextTestCase(_GSSAPIKerberosTestCase):
         server_ctx.verify_signature.should_raise(gb.GSSError,
                                                  b'other message', mic_token)
 
+    @_minversion_test("1.11", "returning tokens")
     def test_defer_step_error_on_method(self):
         gssctx.SecurityContext.__DEFER_STEP_ERRORS__ = True
         bdgs = gb.ChannelBindings(application_data=b'abcxyz')
@@ -671,6 +672,7 @@ class SecurityContextTestCase(_GSSAPIKerberosTestCase):
         server_ctx.step(client_token).should_be_a(bytes)
         server_ctx.encrypt.should_raise(gb.BadChannelBindingsError, b'test')
 
+    @_minversion_test("1.11", "returning tokens")
     def test_defer_step_error_on_complete_property_access(self):
         gssctx.SecurityContext.__DEFER_STEP_ERRORS__ = True
         bdgs = gb.ChannelBindings(application_data=b'abcxyz')


### PR DESCRIPTION
The first commit modifies the test harness to support skipping tests on specific versions of the underlying Kerberos library, and the second commit enables Travis builders on 1.10.