### PR TITLE
Make the method of extending enums a bit more sane

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 dist
 gssapi/**/*.c
 docs/build
+__dont_use_cython__.txt

--- a/gssapi/raw/__init__.py
+++ b/gssapi/raw/__init__.py
@@ -1,3 +1,16 @@
+import pkgutil
+import importlib
+
+from gssapi.raw import _enum_extensions
+
+# NB(directxman12): the enum extensions must be imported BEFORE ANYTHING ELSE!
+for modinf in pkgutil.iter_modules(_enum_extensions.__path__):
+    name = modinf[1]
+    importlib.import_module('{0}._enum_extensions.{1}'.format(__name__, name))
+
+del pkgutil
+del importlib
+
 from gssapi.raw.creds import *  # noqa
 from gssapi.raw.message import *  # noqa
 from gssapi.raw.misc import *  # noqa

--- a/gssapi/raw/_enum_extensions/__init__.py
+++ b/gssapi/raw/_enum_extensions/__init__.py
@@ -1,0 +1,26 @@
+from enum import EnumMeta
+
+
+_extra_values = {}
+
+
+def register_value(cl_str, name, value):
+    _extra_values[cl_str] = _extra_values.get(cl_str, {})
+    _extra_values[cl_str][name] = value
+
+
+class ExtendableEnum(EnumMeta):
+    def __new__(metacl, name, bases, classdict):
+        extra_vals = _extra_values.get(name)
+
+        if extra_vals is not None:
+            for extra_name, extra_val in list(extra_vals.items()):
+                if extra_name in classdict:
+                    raise AttributeError(
+                        "Enumeration extensions cannot override existing "
+                        "enumeration members")
+                else:
+                    classdict[extra_name] = extra_val
+
+        return super(ExtendableEnum, metacl).__new__(metacl, name,
+                                                     bases, classdict)

--- a/gssapi/raw/_enum_extensions/ext_dce.pyx
+++ b/gssapi/raw/_enum_extensions/ext_dce.pyx
@@ -1,0 +1,14 @@
+from gssapi.raw.cython_types cimport OM_uint32
+
+import gssapi.raw._enum_extensions as ext_registry
+
+
+cdef extern from "python_gssapi_ext.h":
+    OM_uint32 GSS_C_DCE_STYLE
+    OM_uint32 GSS_C_IDENTIFY_FLAG
+    OM_uint32 GSS_C_EXTENDED_ERROR_FLAG
+
+ext_registry.register_value('RequirementFlag', 'dce_style', GSS_C_DCE_STYLE)
+ext_registry.register_value('RequirementFlag', 'identify', GSS_C_IDENTIFY_FLAG)
+ext_registry.register_value('RequirementFlag', 'extended_error',
+                            GSS_C_EXTENDED_ERROR_FLAG)

--- a/gssapi/raw/_enum_extensions/ext_iov_mic.pyx
+++ b/gssapi/raw/_enum_extensions/ext_iov_mic.pyx
@@ -1,0 +1,10 @@
+from gssapi.raw.cython_types cimport OM_uint32
+
+from gssapi.raw import _enum_extensions as ext_registry
+
+
+cdef extern from "python_gssapi_ext.h":
+    OM_uint32 GSS_IOV_BUFFER_TYPE_MIC_TOKEN
+
+ext_registry.register_value('IOVBufferType', 'mic_token',
+                            GSS_IOV_BUFFER_TYPE_MIC_TOKEN)

--- a/gssapi/raw/ext_dce.pyx
+++ b/gssapi/raw/ext_dce.pyx
@@ -6,13 +6,14 @@ from libc.string cimport memcpy
 from gssapi.raw.cython_types cimport *
 from gssapi.raw.sec_contexts cimport SecurityContext
 
-from gssapi.raw.misc import GSSError, _EnumExtension
+from gssapi.raw.misc import GSSError
 from gssapi.raw import types as gssapi_types
 from gssapi.raw.named_tuples import IOVUnwrapResult, WrapResult, UnwrapResult
 from collections import namedtuple, Sequence
 
 from enum import IntEnum
 import six
+from gssapi.raw._enum_extensions import ExtendableEnum
 
 cdef extern from "python_gssapi_ext.h":
     # NB(directxman12): this wiki page has a different argument order
@@ -62,12 +63,10 @@ cdef extern from "python_gssapi_ext.h":
     OM_uint32 GSS_IOV_BUFFER_FLAG_ALLOCATE
     OM_uint32 GSS_IOV_BUFFER_FLAG_ALLOCATED
 
-    OM_uint32 GSS_C_DCE_STYLE
-    OM_uint32 GSS_C_IDENTIFY_FLAG
-    OM_uint32 GSS_C_EXTENDED_ERROR_FLAG
+    # a few more are in the enum extension file
 
 
-class IOVBufferType(IntEnum):
+class IOVBufferType(IntEnum, metaclass=ExtendableEnum):
     """
     IOV Buffer Types
 
@@ -86,15 +85,6 @@ class IOVBufferType(IntEnum):
     padding = GSS_IOV_BUFFER_TYPE_PADDING
     stream = GSS_IOV_BUFFER_TYPE_STREAM
     sign_only = GSS_IOV_BUFFER_TYPE_SIGN_ONLY
-
-
-@six.add_metaclass(_EnumExtension)
-class RequirementFlag(object):
-    __base__ = gssapi_types.RequirementFlag
-
-    dce_style = GSS_C_DCE_STYLE
-    identify = GSS_C_IDENTIFY_FLAG
-    extended_error = GSS_C_EXTENDED_ERROR_FLAG
 
 
 IOVBuffer = namedtuple('IOVBuffer', ['type', 'allocate', 'value'])

--- a/gssapi/raw/ext_iov_mic.pyx
+++ b/gssapi/raw/ext_iov_mic.pyx
@@ -4,10 +4,9 @@ from gssapi.raw.cython_types cimport *
 from gssapi.raw.sec_contexts cimport SecurityContext
 from gssapi.raw.ext_dce cimport IOV, gss_iov_buffer_desc
 
-from gssapi.raw.misc import GSSError, _EnumExtension
-from gssapi.raw import ext_dce
+from gssapi.raw.misc import GSSError
+from gssapi.raw.ext_dce import IOVBufferType
 
-import six
 
 cdef extern from "python_gssapi_ext.h":
     OM_uint32 gss_get_mic_iov(OM_uint32 *min_stat, gss_ctx_id_t context_handle,
@@ -26,13 +25,7 @@ cdef extern from "python_gssapi_ext.h":
                                  gss_iov_buffer_desc *iov,
                                  int iov_count) nogil
 
-    OM_uint32 GSS_IOV_BUFFER_TYPE_MIC_TOKEN
-
-
-@six.add_metaclass(_EnumExtension)
-class IOVBufferType(object):
-    __base__ = ext_dce.IOVBufferType
-    mic_token = GSS_IOV_BUFFER_TYPE_MIC_TOKEN
+    # more in the enum extension file
 
 
 IOV.AUTO_ALLOC_BUFFERS.add(IOVBufferType.mic_token)

--- a/gssapi/raw/misc.pyx
+++ b/gssapi/raw/misc.pyx
@@ -9,8 +9,6 @@ from gssapi.raw.oids cimport OID
 
 from gssapi.raw.types import MechType
 
-from enum import EnumMeta, Enum
-
 
 cdef extern from "python_gssapi.h":
     OM_uint32 gss_display_status(OM_uint32 *minor_status,
@@ -328,64 +326,3 @@ class GSSError(Exception, metaclass=GSSErrorRegistry):
                                    maj_str=maj_str,
                                    min_stat=self.min_code,
                                    min_str=min_str)
-
-
-# WARNING: FOR YOUR OWN PERSONAL SANITY, DO NOT TRY THIS AT HOME
-# This allows things like extensions declaring their own RequirementFlags
-# without having to worry about import order.  There *might* be a cleaner
-# way to do this, but most of the ways probably exploit the interals of Enum
-class _EnumExtension(EnumMeta):
-    def __new__(metacls, name, bases, classdict):
-        # find the base class that this overrides
-
-        base_attr = classdict.get('__base__', None)
-
-        if len(bases) != 1 or bases[0] is not object or base_attr is None:
-            raise TypeError("Enumeration extensions must be created as "
-                            "`ClassName(object)` and must contain the "
-                            "`__base__` attribute")
-
-        adds_to = base_attr
-        del classdict['__base__']
-
-        bases = adds_to.__bases__
-
-        # we need to have the same Enum type
-        if not issubclass(adds_to, Enum):
-            raise TypeError("Enumeration extensions must extend a subtype "
-                            "of Enum or directly sublcass object")
-
-        # roughly preserve insertion order in Python 3.4+
-        # (actually preserving order would require using parts of the Enum
-        # implementation that aren't part of the spec)
-        old_classdict = classdict
-        classdict = metacls.__prepare__(name, bases)
-
-        # NB(directxman12): we can't use update, because that doesn't
-        # trigger __setitem__, which thus won't update the _EnumDict correctly
-        base_members = adds_to.__members__
-        for k, v in base_members.items():
-            classdict[k] = v.value
-
-        for k, v in old_classdict.items():
-            if k in base_members:
-                raise AttributeError("Enumeration extensions cannot override "
-                                     "existing enumeration members")
-
-            classdict[k] = v
-
-        res = super(_EnumExtension, metacls).__new__(metacls, name,
-                                                     bases, classdict)
-
-        # replace the old with the new
-        for k, v in res.__dict__.items():
-            if (k not in ('__module__', '__qualname__', '__doc__') and
-                    k in adds_to.__dict__):
-                setattr(adds_to, k, v)
-
-        # preserve enum semantics
-        for member in adds_to.__members__.values():
-            member.__class__ = adds_to
-
-        # always return the original
-        return adds_to

--- a/gssapi/raw/types.pyx
+++ b/gssapi/raw/types.pyx
@@ -4,11 +4,14 @@ from gssapi.raw.cython_types cimport *
 from gssapi.raw.cython_converters cimport c_make_oid
 from gssapi.raw.oids cimport OID
 
+from gssapi.raw._enum_extensions import ExtendableEnum
+
 from enum import IntEnum
 import collections
 import copy
 import numbers
 import operator
+import six
 
 
 class NameType(object):
@@ -36,7 +39,7 @@ class NameType(object):
     # mech-specific name types are added automatically on import
 
 
-class RequirementFlag(IntEnum):
+class RequirementFlag(IntEnum, metaclass=ExtendableEnum):
     """
     GSSAPI Requirement Flags
 
@@ -58,7 +61,7 @@ class RequirementFlag(IntEnum):
     transferable = GSS_C_TRANS_FLAG
 
 
-class AddressType(IntEnum):
+class AddressType(IntEnum, metaclass=ExtendableEnum):
     """
     GSSAPI Channel Bindings Address Types
 

--- a/gssapi/tests/test_raw.py
+++ b/gssapi/tests/test_raw.py
@@ -5,8 +5,6 @@ import socket
 import unittest
 
 import should_be.all  # noqa
-from enum import IntEnum
-import six
 
 import gssapi.raw as gb
 import gssapi.raw.misc as gbmisc
@@ -641,78 +639,6 @@ class TestIntEnumFlagSet(unittest.TestCase):
         fset3.shouldnt_include(gb.RequirementFlag.confidentiality)
         fset3.should_include(gb.RequirementFlag.protection_ready)
         fset3.should_include(gb.RequirementFlag.out_of_sequence_detection)
-
-
-class TestEnumExtension(unittest.TestCase):
-    def setUp(self):
-        class ExtendedEnum(IntEnum):
-            """some docs"""
-            a = 1
-            b = 2
-            c = 3
-
-        class OtherEnum(IntEnum):
-            a = 1
-            b = 2
-            c = 3
-
-        self._ext_enum = ExtendedEnum
-        self._plain_enum = OtherEnum
-
-    def test_same_dict(self):
-        @six.add_metaclass(gbmisc._EnumExtension)
-        class ExtendedEnum(object):
-            __base__ = self._ext_enum
-            d = 4
-            e = 5
-
-        self._ext_enum.__dict__.keys().should_be(
-                self._plain_enum.__dict__.keys())
-
-    def test_members_copy_mult(self):
-        @six.add_metaclass(gbmisc._EnumExtension)
-        class ExtendedEnum(object):
-            __base__ = self._ext_enum
-            d = 4
-
-        @six.add_metaclass(gbmisc._EnumExtension)
-        class ExtendedEnum2(object):
-            __base__ = self._ext_enum
-            e = 5
-
-        self._ext_enum.__members__.should_include(
-            ['a', 'b', 'c', 'd', 'e'])
-
-        self._ext_enum.a.should_be(1)
-        self._ext_enum.b.should_be(2)
-        self._ext_enum.c.should_be(3)
-        self._ext_enum.d.should_be(4)
-        self._ext_enum.e.should_be(5)
-
-    def test_all_class_are_same(self):
-        @six.add_metaclass(gbmisc._EnumExtension)
-        class ExtendedEnum(object):
-            __base__ = self._ext_enum
-            d = 4
-
-        assert ExtendedEnum is self._ext_enum
-
-    def test_members_are_still_instance(self):
-        @six.add_metaclass(gbmisc._EnumExtension)
-        class EnumExt(object):
-            __base__ = self._ext_enum
-            d = 4
-
-        self._ext_enum.a.should_be_a(self._ext_enum)
-        self._ext_enum.d.should_be_a(self._ext_enum)
-
-    def test_doc_is_preserved(self):
-        @six.add_metaclass(gbmisc._EnumExtension)
-        class ExtendedEnum(object):
-            __base__ = self._ext_enum
-            d = 4
-
-        self._ext_enum.__doc__.should_be('some docs')
 
 
 class TestInitContext(_GSSAPIKerberosTestCase):

--- a/setup.py
+++ b/setup.py
@@ -118,10 +118,23 @@ def main_file(module):
                      sources=['gssapi/raw/%s.%s' % (module, SOURCE_EXT)])
 
 
+ENUM_EXTS = []
+
+
 def extension_file(module, canary):
     if ENABLE_SUPPORT_DETECTION and not hasattr(GSSAPI_LIB, canary):
         return None
     else:
+        enum_ext_path = 'gssapi/raw/_enum_extensions/ext_%s.%s' % (module,
+                                                                   SOURCE_EXT)
+        if os.path.exists(enum_ext_path):
+            ENUM_EXTS.append(
+                Extension('gssapi.raw._enum_extensions.ext_%s' % module,
+                          extra_link_args=link_args,
+                          extra_compile_args=compile_args,
+                          sources=[enum_ext_path],
+                          include_dirs=['gssapi/raw/']))
+
         return Extension('gssapi.raw.ext_%s' % module,
                          extra_link_args=link_args,
                          extra_compile_args=compile_args,
@@ -142,6 +155,9 @@ def gssapi_modules(lst):
                              sources=['gssapi/raw/mech_%s.%s' % (mech,
                                                                  SOURCE_EXT)]))
 
+    # add in any present enum extension files
+    res.extend(ENUM_EXTS)
+
     if SOURCE_EXT == 'pyx':
         res = cythonize(res)
 
@@ -157,7 +173,8 @@ setup(
     version='1.0.0',
     author='The Python GSSAPI Team',
     author_email='sross@redhat.com',
-    packages=['gssapi', 'gssapi.raw', 'gssapi.tests'],
+    packages=['gssapi', 'gssapi.raw', 'gssapi.raw._enum_extensions',
+              'gssapi.tests'],
     description='Python GSSAPI Wrapper',
     long_description=long_desc,
     license='LICENSE.txt',


### PR DESCRIPTION
This new way doesn't involve nearly as much hackery.
However, enum extensions must be in a separate submodule
(a module under `gssapi.raw._enum_extensions`), and should
be called the same thing as the corresponding extension
(due to the way that `setup.py` is written).  Additionally,
the import of the aforementioned submodules *must* happen
before importing any other python-gssapi modules (hence they
have to happen at the top of 'gssapi/raw/__init__.py').  This
limits the ability to allow for third parties writing extension
bindings (although that's probably not something that should be
done).  Finally, due to the way it works, each extenable enum
must be decorated beforehand, and must not share a name with
any other extendable enum.