### PR TITLE
Automatically upload checksumed taball on release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ dist
 gssapi/**/*.c
 docs/build
 __dont_use_cython__.txt
+**/__pycache__
+.eggs

--- a/.travis.before-deploy.sh
+++ b/.travis.before-deploy.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# clean up
+git clean -Xdf
+
+# make the dir
+mkdir ./tag_build
+
+# create and checksum the tarball
+tar -czvf ./tag_build/${TRAVIS_TAG}.tar.gz --exclude='tag_build' --exclude='.git' --transform "s,^\.,python-gssapi-${TRAVIS_TAG}," .
+md5sum --binary ./tag_build/${TRAVIS_TAG}.tar.gz > ./tag_build/${TRAVIS_TAG}.md5sum

--- a/.travis.install.sh
+++ b/.travis.install.sh
@@ -1,0 +1,17 @@
+#!/bin/sh -ex
+
+sudo sed -i '1i 127.0.0.1 test.box' /etc/hosts
+sudo hostname test.box
+
+if [ x"$KRB5_VER" != "x1.10" ]; then
+    sudo apt-add-repository -y ppa:sssd/updates
+
+    if [ x"$KRB5_VER" != "x1.12" ]; then
+        sudo apt-add-repository -y ppa:rharwood/krb5-$KRB5_VER
+    fi
+fi
+
+sudo apt-get update -q
+DEBIAN_FRONTEND=noninteractive sudo apt-get install -y krb5-user krb5-kdc krb5-admin-server libkrb5-dev krb5-multidev
+pip install --install-option='--no-cython-compile' cython
+pip install -r test-requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,17 @@ matrix:
 install: sh .travis.install.sh
 
 script: sh .travis.sh
+
+before_deploy: sh .travis.before-deploy.sh
+deploy:
+  provider: releases
+  api_key:
+    secure: U8RPR6liglI4J8MOSEyK9uxvSFRMcCkKLflpIFKcpUFg+PUuK85YtRdOOL/L/pifat9/KvoF7OJEMNTQjoYAhziMu8GGsiPZlkFzXNiy54FxTTtgprkhllRK7nw/jK/hopKM01goKVaUL860aU+KdpfStRTaAy8ZGEj13jwOMYU=
+  file:
+    - tag_build/${TRAVIS_TAG}.md5sum
+    - tag_build/${TRAVIS_TAG}.tar.gz
+  on:
+    repo: pythongssapi/python-gssapi
+    tags: true
+    python: "3.4"
+    condition: "$KRB5_VER = '1.13'"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,26 +4,19 @@ python:
   - "3.4"
 
 env:
-  - KRB5_PPAS="" # 1.10
-  - KRB5_PPAS="sssd/updates" # 1.12
-  - KRB5_PPAS="rharwood/krb5-1.13 sssd/updates" # 1.13
-  - KRB5_PPAS="rharwood/krb5-master sssd/updates" # master
+  - KRB5_VER="1.10"
+  - KRB5_VER="1.12"
+  - KRB5_VER="1.13"
+  - KRB5_VER="master"
 
 matrix:
   exclude:
     - python: "3.4"
-      env: KRB5_PPAS="" # 1.10
+      env: KRB5_VER="1.10"
   include:
     - python: "3.3"
-      env: KRB5_PPAS="sssd/updates" # 1.12
+      env: KRB5_VER="1.12"
 
-install:
-  - "sudo sed -i '1i 127.0.0.1 test.box' /etc/hosts"
-  - "sudo hostname test.box"
-  - "for i in $KRB5_PPAS; do sudo apt-add-repository -y ppa:$i; done"
-  - "sudo apt-get update -q"
-  - "DEBIAN_FRONTEND=noninteractive sudo apt-get install -y krb5-user krb5-kdc krb5-admin-server libkrb5-dev krb5-multidev"
-  - "pip install --install-option='--no-cython-compile' cython"
-  - "pip install -r test-requirements.txt"
+install: sh .travis.install.sh
 
 script: sh .travis.sh


### PR DESCRIPTION
This uploads a compressed tarball, as well as a checksum, for every tagged release.
The files will be uploaded once the Python 3.4 run of the krb5 1.13 (the latest released
version) tests completes.  The tarball has essentially the same contents as the github tarball.
However, since it is only created once, it has a consistent checksum (unlike the GitHub tarball,
which is created on demand, and thus may have different checksums).