### PR TITLE
krb-console utility

### DIFF
--- a/gssapi-console.py
+++ b/gssapi-console.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python
+
+# interactive console with easy access to krb5 test harness stuff
+
+import code
+import os
+import sys
+import copy
+
+from gssapi.tests import k5test
+
+
+READLINE_SRC = """
+# python startup file
+import readline
+import rlcompleter
+import atexit
+import os
+
+completer = rlcompleter.Completer(globals())
+readline.set_completer(completer.complete)
+
+# tab completion
+readline.parse_and_bind('Control-space: complete')
+# history file
+histfile = os.path.join(os.environ['HOME'], '.pythonhistory')
+try:
+    readline.read_history_file(histfile)
+except IOError:
+    pass
+
+atexit.register(readline.write_history_file, histfile)
+del os, histfile, readline, rlcompleter
+"""
+
+BANNER = """GSSAPI Interactive console
+Python {ver} on {platform}
+Type "help", "copyright", "credits" or "license" for more information about Python.
+
+mechansim: {mech}, realm: {realm}, user: {user}, host: {host}
+(functions for controlling the realm available in `REALM`)"""
+
+
+class GSSAPIConsole(code.InteractiveConsole):
+    def __init__(self, use_readline=True, realm_args={}, *args, **kwargs):
+        code.InteractiveConsole.__init__(self, *args, **kwargs)
+
+        self.realm = self._create_realm(realm_args)
+        self.locals['REALM'] = self.realm
+
+        self.runsource('import gssapi')
+        self.runsource('import gssapi.raw as gb')
+
+        if use_readline:
+            self._add_readline()
+
+        if os.environ.get('LD_LIBRARY_PATH'):
+            self.realm.env['LD_LIBRARY_PATH'] = os.environ['LD_LIBRARY_PATH']
+
+    def _create_realm(self):
+        return None
+
+    def _add_readline(self):
+        res = self.runsource(READLINE_SRC, '<readline setup>', 'exec')
+
+
+class Krb5Console(GSSAPIConsole):
+    def _create_realm(self, realm_args):
+        return k5test.K5Realm(**realm_args)
+
+
+MECH_MAP = {'krb5': Krb5Console}
+
+
+import argparse
+parser = argparse.ArgumentParser(description='An interactive Python console with krb5 setup')
+parser.add_argument('file', metavar='FILE', nargs='?',
+                    help='a file to run', default=None)
+parser.add_argument('-i', default=False, dest='force_interactive',
+                    action='store_const', const=True,
+                    help='Force interactive mode when running with a file')
+parser.add_argument('--realm-args', default=None,
+                    help='A comma-separated list of key=(true|false) values to '
+                         'pass to the realm constructor')
+parser.add_argument('--mech', default='krb5',
+                    help='Which environment to setup up '
+                         '(supports krb5 [default])')
+
+PARSED_ARGS = parser.parse_args()
+
+
+if PARSED_ARGS.mech not in MECH_MAP:
+    sys.exit('The %s environment is not supported by the '
+             'GSSAPI console' % PARSED_ARGS.mech)
+
+
+realm_args = {}
+if PARSED_ARGS.realm_args:
+    for arg in PARSED_ARGS.realm_args.split(','):
+        key, raw_val = arg.split('=')
+        realm_args[key] = (raw_val.lower() == 'true')
+
+console = MECH_MAP[PARSED_ARGS.mech](realm_args=realm_args)
+SAVED_ENV = None
+
+try:
+    # create the banner
+    banner_text = BANNER.format(ver=sys.version, platform=sys.platform,
+                                mech=PARSED_ARGS.mech,
+                                realm=console.realm.realm,
+                                user=console.realm.user_princ,
+                                host=console.realm.host_princ)
+
+    # import the env
+    SAVED_ENV = copy.deepcopy(os.environ)
+    for k,v in console.realm.env.items():
+        os.environ[k] = v
+
+    INTER = True
+    # run the interactive interpreter
+    if PARSED_ARGS.file is not None:
+        if not PARSED_ARGS.force_interactive:
+            INTER = False
+
+        with open(PARSED_ARGS.file) as src:
+            console.runsource(src.read(), src.name, 'exec')
+
+    if INTER:
+        console.interact(banner_text)
+
+except (KeyboardInterrupt, EOFError):
+    pass
+finally:
+    # restore the env
+    if SAVED_ENV is not None:
+        for k in copy.deepcopy(os.environ):
+            if k in SAVED_ENV:
+                os.environ[k] = SAVED_ENV[k]
+            else:
+                del os.environ[k]
+
+    console.realm.stop()

--- a/gssapi/tests/_utils.py
+++ b/gssapi/tests/_utils.py
@@ -1,17 +1,13 @@
+import os
+import subprocess
+
 from gssapi._utils import import_gssapi_extension
 
-try:
-    import commands
-    get_output = commands.getoutput
-except ImportError:
-    import subprocess
 
-    def _get_output(*args, **kwargs):
-        res = subprocess.check_output(*args, shell=True, **kwargs)
-        decoded = res.decode('utf-8')
-        return decoded.strip()
-
-    get_output = _get_output
+def get_output(*args, **kwargs):
+    res = subprocess.check_output(*args, shell=True, **kwargs)
+    decoded = res.decode('utf-8')
+    return decoded.strip()
 
 
 def _extension_test(extension_name, extension_text):
@@ -47,3 +43,80 @@ def _minversion_test(target_version, problem):
         return ext_test
 
     return make_ext_test
+
+
+_PLUGIN_DIR = None
+
+
+def _find_plugin_dir():
+    global _PLUGIN_DIR
+    if _PLUGIN_DIR is not None:
+        return _PLUGIN_DIR
+
+    # if we've set a LD_LIBRARY_PATH, use that first
+    ld_path_raw = os.environ.get('LD_LIBRARY_PATH')
+    if ld_path_raw is not None:
+        # first, try assuming it's just a normal install
+
+        ld_paths = [path for path in ld_path_raw.split(':') if path]
+
+        for ld_path in ld_paths:
+            if not os.path.exists(ld_path):
+                continue
+
+            _PLUGIN_DIR = _decide_plugin_dir(
+                _find_plugin_dirs_installed(ld_path))
+            if _PLUGIN_DIR is None:
+                _PLUGIN_DIR = _decide_plugin_dir(
+                    _find_plugin_dirs_src(ld_path))
+
+            if _PLUGIN_DIR is not None:
+                break
+
+    # if there was no LD_LIBRARY_PATH, or the above failed
+    if _PLUGIN_DIR is None:
+        # if we don't have a LD_LIBRARY_PATH, just search in
+        # $prefix/lib
+
+        lib_dir = os.path.join(get_output('krb5-config --prefix'), 'lib')
+        _PLUGIN_DIR = _decide_plugin_dir(_find_plugin_dirs_installed(lib_dir))
+
+    if _PLUGIN_DIR is not None:
+        _PLUGIN_DIR = os.path.normpath(_PLUGIN_DIR)
+        return _PLUGIN_DIR
+    else:
+        return None
+
+
+def _decide_plugin_dir(dirs):
+    if dirs is None:
+        return None
+
+    # the shortest path is probably more correct
+    shortest_first = sorted(dirs, key=len)
+
+    for path in shortest_first:
+        # check to see if it actually contains .so files
+        if get_output('find %s -name "*.so"' % path):
+            return path
+
+    return None
+
+
+def _find_plugin_dirs_installed(search_path):
+    options_raw = get_output('find %s/ -type d '
+                             '-path "*/krb5/plugins"' % search_path)
+
+    if options_raw:
+        return options_raw.split('\n')
+    else:
+        return None
+
+
+def _find_plugin_dirs_src(search_path):
+    options_raw = get_output('find %s/../ -type d -name plugins' % search_path)
+
+    if options_raw:
+        return options_raw.split('\n')
+    else:
+        return None

--- a/gssapi/tests/k5test.py
+++ b/gssapi/tests/k5test.py
@@ -37,6 +37,8 @@ import unittest
 
 import six
 
+from gssapi.tests import _utils
+
 
 def _cfg_merge(cfg1, cfg2):
     if not cfg2:
@@ -85,6 +87,8 @@ _default_kdc_conf = {
             'kdc_tcp_ports': '$port0',
             'database_name': '$tmpdir/db'}},
     'dbmodules': {
+        'db_module_dir': os.path.join(_utils._find_plugin_dir(),
+                                      'kdb'),
         'db': {'db_library': 'db2', 'database_name': '$tmpdir/db'}},
     'logging': {
         'admin_server': 'FILE:$tmpdir/kadmind5.log',


### PR DESCRIPTION
This commit introduces support for the krb-console utility, which is an interactive Python console which automatically sets up and tears down
a self-contained krb5 realm.  This allows the user to experiment around with the GSSAPI bindings without having to worry about
having or changing an existing krb5 setup.

This commit also introduces a utility method for locating the plugins dir, which was necessary to fix the k5test configuration
when run wholly under a LD_LIBRARY_PATH to a newer installation.