### PR TITLE
Fix plugin detection for subdirectories of /usr/lib

### DIFF
--- a/.travis.install.sh
+++ b/.travis.install.sh
@@ -13,5 +13,6 @@ fi
 
 sudo apt-get update -q
 DEBIAN_FRONTEND=noninteractive sudo apt-get install -y krb5-user krb5-kdc krb5-admin-server libkrb5-dev krb5-multidev
+DEBIAN_FRONTEND=noninteractive sudo apt-get -y install krb5-greet-client || true
 pip install --install-option='--no-cython-compile' cython
 pip install -r test-requirements.txt

--- a/gssapi/tests/_utils.py
+++ b/gssapi/tests/_utils.py
@@ -122,15 +122,8 @@ def _find_plugin_dirs_src(search_path):
         return None
 
 
-_KRB_PREFIX = None
-
-
 def _requires_krb_plugin(plugin_type, plugin_name):
-    global _KRB_PREFIX
-    if _KRB_PREFIX is None:
-        _KRB_PREFIX = get_output("krb5-config --prefix")
-
-    plugin_path = os.path.join(_KRB_PREFIX, 'lib/krb5/plugins',
+    plugin_path = os.path.join(_find_plugin_dir(),
                                plugin_type, '%s.so' % plugin_name)
 
     def make_krb_plugin_test(func):


### PR DESCRIPTION
Combined with changes to the krb5-1.13 packaging, this will cause the
greet_client tests to pass on travis.

Closes #57. 