### PR TITLE
[travis] Switch to using Trusty builder

### DIFF
--- a/.travis.install.sh
+++ b/.travis.install.sh
@@ -10,12 +10,8 @@ if [ x"$KRB5_VER" = "xheimdal" ]; then
     sudo apt-get update
     DEBIAN_FRONTEND=noninteractive sudo apt-get -y install heimdal-dev
     exit 0
-elif [ x"$KRB5_VER" != "x1.10" ]; then
-    sudo apt-add-repository -y ppa:sssd/updates
-
-    if [ x"$KRB5_VER" != "x1.12" ]; then
-        sudo apt-add-repository -y ppa:rharwood/krb5-$KRB5_VER
-    fi
+elif [ x"$KRB5_VER" != "x1.12" ]; then
+    sudo apt-add-repository -y ppa:rharwood/krb5-$KRB5_VER
 fi
 
 sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,21 @@
+sudo: required
+dist: trusty
+
 language: python
 python:
   - "2.7"
   - "3.5"
 
 env:
-  - KRB5_VER="1.10"
+  # - KRB5_VER="1.10"
   - KRB5_VER="1.12"
   - KRB5_VER="1.13"
   # - KRB5_VER="master"
 
 matrix:
-  exclude:
-    - python: "3.5"
-      env: KRB5_VER="1.10"
+  # exclude:
+  #   - python: "3.5"
+  #     env: KRB5_VER="1.10"
   include:
     - python: "3.3"
       env: KRB5_VER="1.12"


### PR DESCRIPTION
Going forward, it looks like Travis will be pushing migration to Trusty, which is reasonable.  This will also need to happen if we want to migrate to containers as far as I can tell.  More information on what this entails in [Travis's writeup](https://docs.travis-ci.com/user/trusty-ci-environment/).
