### PR TITLE
Fix Delegated Credentials Issues

### DIFF
--- a/gssapi/sec_contexts.py
+++ b/gssapi/sec_contexts.py
@@ -511,7 +511,10 @@ class SecurityContext(rsec_contexts.SecurityContext):
         res = rsec_contexts.accept_sec_context(token, self._creds,
                                                self, self._channel_bindings)
 
-        self.delegated_creds = Credentials(res.delegated_creds)
+        if res.delegated_creds is not None:
+            self.delegated_creds = Credentials(res.delegated_creds)
+        else:
+            self.delegated_creds = None
 
         self._complete = not res.more_steps
 


### PR DESCRIPTION
This PR contains a fix for #95 (exposing `delegated_creds` as a property).

It also contains a partial fix for #96 (setting `delegated_creds` to `None` if no delegated credentials are returned by the low-level API, and only wrapping the result in a high-level `Credentials` API if delegated credentials are actually returned), which should have while we debate a longer-term solution.