### PR TITLE
Force overwrite on cred_store tests

### DIFF
--- a/gssapi/tests/test_high_level.py
+++ b/gssapi/tests/test_high_level.py
@@ -173,7 +173,8 @@ class CredsTestCase(_GSSAPIKerberosTestCase):
         deleg_creds = server_ctx.delegated_creds
         deleg_creds.shouldnt_be_none()
 
-        store_res = deleg_creds.store(usage='initiate', set_default=True)
+        store_res = deleg_creds.store(usage='initiate', set_default=True,
+                                      overwrite=True)
         store_res.usage.should_be('initiate')
         store_res.mechs.should_include(gb.MechType.kerberos)
 

--- a/gssapi/tests/test_raw.py
+++ b/gssapi/tests/test_raw.py
@@ -475,7 +475,7 @@ class TestBaseUtilities(_GSSAPIKerberosTestCase):
         deleg_creds = server_ctx_resp.delegated_creds
         deleg_creds.shouldnt_be_none()
         store_res = gb.store_cred(deleg_creds, usage='initiate',
-                                  set_default=True)
+                                  set_default=True, overwrite=True)
 
         store_res.shouldnt_be_none()
         store_res.usage.should_be('initiate')


### PR DESCRIPTION
Certain versions of krb5 (>= 1.14 or anything that backported the
patch, including RHEL/Centos/Fedora) object (probably rightly so) to
duplicate credentials already existing in the ccache.  Tell those
versions to sit down and shut up.

This is the third and final commit in a series to enable running our
test suite on RHEL-7.

For posterity, to see the rest of the series, look at my nomerge/rhel7_patched branch.  The first commit was merged as pythongssapi/k5test#1 and the second (a workaround for old cython versions) is not planned for merge at this time.