### PR TITLE
Update parameterized

### DIFF
--- a/gssapi/tests/test_high_level.py
+++ b/gssapi/tests/test_high_level.py
@@ -6,7 +6,7 @@ import pickle
 
 import should_be.all  # noqa
 import six
-from nose_parameterized import parameterized
+from parameterized import parameterized
 
 from gssapi import creds as gsscreds
 from gssapi import mechs as gssmechs

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 flake8
 nose
-nose_parameterized
+parameterized
 shouldbe
 six
 Cython


### PR DESCRIPTION
It appears that `node-parameterized` has been [deprecated](https://pypi.python.org/pypi/nose-parameterized#deprecation-warning). Updating to `parameterized` doesn't appear to break the test suite. 