### PR TITLE
Fix OID inequality comparison

### DIFF
--- a/gssapi/raw/oids.pyx
+++ b/gssapi/raw/oids.pyx
@@ -155,7 +155,7 @@ cdef class OID:
         return hash(self.__bytes__())
 
     def __richcmp__(OID self, OID other, op):
-        if op == 2 or op == 3:  # ==
+        if op == 2:  # ==
             return c_compare_oids(&self.raw_oid, &other.raw_oid)
         elif op == 3:  # !=
             return not c_compare_oids(&self.raw_oid, &other.raw_oid)

--- a/gssapi/tests/test_raw.py
+++ b/gssapi/tests/test_raw.py
@@ -1353,3 +1353,13 @@ class TestOIDTransforms(unittest.TestCase):
             int_seq = oid['string'].split('.')
             o = gb.OID.from_int_seq(int_seq)
             o.__bytes__().should_be(oid['bytes'])
+
+    def test_comparisons(self):
+        krb5 = gb.OID.from_int_seq(TEST_OIDS['KRB5']['string'])
+        krb5_other = gb.OID.from_int_seq(TEST_OIDS['KRB5']['string'])
+        spnego = gb.OID.from_int_seq(TEST_OIDS['SPNEGO']['string'])
+
+        (krb5 == krb5_other).should_be(True)
+        (krb5 == spnego).should_be(False)
+        (krb5 != krb5_other).should_be(False)
+        (krb5 != spnego).should_be(True)


### PR DESCRIPTION
Due to an extraneous 'or' branch, OID inequality
comparison would return the results of an equality
comparison.