### PR TITLE
allow setup to override the krb5-config path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,8 @@ link_args = link_args.split()
 compile_args = compile_args.split()
 
 # add in the extra workarounds for different include structures
-prefix = get_output('krb5-config gssapi --prefix')
+prefix_path = os.environ.get("GSSAPI_CONFIG_PATH", "krb5-config")
+prefix = get_output('%s gssapi --prefix' % prefix_path)
 gssapi_ext_h = os.path.join(prefix, 'include/gssapi/gssapi_ext.h')
 if os.path.exists(gssapi_ext_h):
     compile_args.append("-DHAS_GSSAPI_EXT_H")


### PR DESCRIPTION
This change allows a user to override the default path used to to determine the krb5 install prefix if they don't want to default system one to be used. I had to override this so that I could get python-gssapi to compile with the MIT krb5 install I had on MacOS compared to the default Heimdal one which doesn't support some of the extensions I had.

Side note if you know of a better way of doing this please let me know.