### PR TITLE
Added MacOS to Travis-CI build tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,7 @@ language: python
 services:
   - docker
 
-env:
-  - DISTRO=debian:stable PYTHON="2"
-  - DISTRO=debian:stable PYTHON="3" # 3.4, not 3.5
-  - DISTRO=debian:stable PYTHON="3" KRB5_VER="heimdal"
-  - DISTRO=centos:7 PYTHON="2" # el7 doesn't do python3 modules
-  - DISTRO=fedora:rawhide PYTHON="3"
-  - DISTRO=fedora:rawhide PYTHON="2"
-
-# we do everything in docker
+# we do everything in docker for non MacOS, MacOS setup is in .travis/build.sh
 install: skip
 before_install: skip
 
@@ -27,10 +19,11 @@ stages:
   if: tag is PRESENT
 
 script:
-  - sudo sed -i '1i 127.0.0.1 test.box' /etc/hosts
-  - sudo hostname test.box
-  - source ./.travis/lib-util.sh
-  - util::docker-run $DISTRO ./.travis/build.sh
+- if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then sudo sed -i '1i 127.0.0.1 test.box' /etc/hosts; fi
+- if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then sudo hostname test.box; fi
+- if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then source ./.travis/lib-util.sh; fi
+- if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then util::docker-run $DISTRO ./.travis/build.sh; fi
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./.travis/build.sh; fi
 
 jobs:
   include:
@@ -45,6 +38,39 @@ jobs:
     script:
     - source ./.travis/lib-util.sh
     - util::docker-run $DISTRO ./.travis/verify.sh
+
+
+  # need to explictly define each builder for test due to different os types
+  - stage: test
+    env: DISTRO=debian:stable PYTHON="2"
+
+  - stage: test
+    env: DISTRO=debian:stable PYTHON="3" # 3.4, not 3.5
+
+  - stage: test
+    env: DISTRO=debian:stable PYTHON="3" KRB5_VER="heimdal"
+
+  - stage: test
+    env: DISTRO=centos:7 PYTHON="2" # el7 doesn't do python3 modules
+
+  - stage: test
+    env: DISTRO=fedora:rawhide PYTHON="3"
+
+  - stage: test
+    env: DISTRO=fedora:rawhide PYTHON="2"
+
+  - stage: test
+    env: PYTHON="2" KRB5_VER="heimdal" PYENV="2.7.14"
+    os: osx
+    osx_image: xcode9.2
+    language: generic # causes issues with pyenv installer when set to python
+
+  - stage: test
+    env: PYTHON="3" KRB5_VER="heimdal" PYENV="3.6.3"
+    os: osx
+    osx_image: xcode9.2
+    language: generic # causes issues with pyenv installer when set to python
+
 
   - stage: deploy latest docs
     script: skip
@@ -97,10 +123,9 @@ jobs:
         all_branches: true
       # NB(directxman12): this is a hack.  Check ./.travis/before-deploy.sh for an explanation.
       distributions: "check"
-    
+
     - provider: script
       script: .travis/docs-deploy.sh travis_docs_build/html stable pythongssapi/python-gssapi
       skip_cleanup: true
       on:
         all_branches: true
-

--- a/.travis/lib-setup.sh
+++ b/.travis/lib-setup.sh
@@ -64,11 +64,22 @@ setup::rh::install() {
     fi
 }
 
+setup::macos::install() {
+    # install Python from pyenv so we know what version is being used
+    pyenv install $PYENV
+    pyenv global $PYENV
+    virtualenv -p $(pyenv which python) .venv
+    source ./.venv/bin/activate
+    pip install --install-option='--no-cython-compile' cython
+}
+
 setup::install() {
     if [ -f /etc/debian_version ]; then
         setup::debian::install
     elif [ -f /etc/redhat-release ]; then
         setup::rh::install
+    elif [ "$(uname)" == "Darwin" ]; then
+        setup::macos::install
     else
         echo "Distro not found!"
         false


### PR DESCRIPTION
Added basic build verification when running on a MacOS host. Doesn't actually run the tests themselves but will verify python-gssapi will compile and install.

Partially covers https://github.com/pythongssapi/python-gssapi/issues/119