### PR TITLE
build on mingw - part 1

### DIFF
--- a/gssapi/raw/python_gssapi.h
+++ b/gssapi/raw/python_gssapi.h
@@ -1,5 +1,7 @@
 #ifdef OSX_HAS_GSS_FRAMEWORK
 #include <GSS/GSS.h>
+#elif __MINGW32__
+#include <gss.h>
 #else
 #include <gssapi/gssapi.h>
 #endif

--- a/gssapi/raw/python_gssapi_ext.h
+++ b/gssapi/raw/python_gssapi_ext.h
@@ -1,9 +1,13 @@
 #ifdef OSX_HAS_GSS_FRAMEWORK
 #include <GSS/GSS.h>
 #else
+#ifdef __MINGW32__
+#include <gss.h>
+#else
 #ifdef HAS_GSSAPI_EXT_H
 #include <gssapi/gssapi_ext.h>
 #else
 #include <gssapi/gssapi.h>
+#endif
 #endif
 #endif

--- a/gssapi/raw/python_gssapi_krb5.h
+++ b/gssapi/raw/python_gssapi_krb5.h
@@ -1,5 +1,7 @@
 #ifdef OSX_HAS_GSS_FRAMEWORK
 #include <GSS/gssapi_krb5.h>
+#elif __MINGW32__
+#include <gss.h>
 #else
 #include <gssapi/gssapi_krb5.h>
 #endif

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,10 @@ link_args = link_args.split()
 compile_args = compile_args.split()
 
 # add in the extra workarounds for different include structures
-prefix = get_output('krb5-config gssapi --prefix')
+try:
+    prefix = get_output('krb5-config gssapi --prefix')
+except:
+    prefix = sys.prefix
 gssapi_ext_h = os.path.join(prefix, 'include/gssapi/gssapi_ext.h')
 if os.path.exists(gssapi_ext_h):
     compile_args.append("-DHAS_GSSAPI_EXT_H")

--- a/setup.py
+++ b/setup.py
@@ -52,12 +52,16 @@ if sys.platform == 'darwin':
 if link_args is None:
     if osx_has_gss_framework:
         link_args = '-framework GSS'
+    elif os.environ.get('MINGW_PREFIX'):
+        link_args = '-lgss'
     else:
         link_args = get_output('krb5-config --libs gssapi')
 
 if compile_args is None:
     if osx_has_gss_framework:
         compile_args = '-framework GSS -DOSX_HAS_GSS_FRAMEWORK'
+    elif os.environ.get('MINGW_PREFIX'):
+        compile_args = '-fPIC'
     else:
         compile_args = get_output('krb5-config --cflags gssapi')
 
@@ -88,6 +92,8 @@ if ENABLE_SUPPORT_DETECTION:
     main_path = ""
     if main_lib is None and osx_has_gss_framework:
         main_lib = ctypes.util.find_library('GSS')
+    elif os.environ.get('MINGW_PREFIX'):
+        main_lib = os.environ.get('MINGW_PREFIX')+'/bin/libgss-3.dll'
     elif main_lib is None:
         for opt in link_args:
             if opt.startswith('-lgssapi'):

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ compile_args = compile_args.split()
 # add in the extra workarounds for different include structures
 try:
     prefix = get_output('krb5-config gssapi --prefix')
-except:
+except Exception:
     prefix = sys.prefix
 gssapi_ext_h = os.path.join(prefix, 'include/gssapi/gssapi_ext.h')
 if os.path.exists(gssapi_ext_h):


### PR DESCRIPTION
This part should be uncontroversial and does nothing unless:
- the preprocessor __MINGW32__ definition is present (header files)
- detects mingw uisng MINGW_PREFIX the environment variable in setup.py