### PR TITLE
Handle GSS_C_NO_OID_SET when creating sets

### DIFF
--- a/.travis/lib-setup.sh
+++ b/.travis/lib-setup.sh
@@ -20,7 +20,8 @@ setup::debian::install() {
     if [ x"$KRB5_VER" = "xheimdal" ]; then
         apt-get -y install heimdal-dev
     else
-        apt-get -y install krb5-{user,kdc,admin-server,multidev} libkrb5-dev
+        apt-get -y install krb5-{user,kdc,admin-server,multidev} libkrb5-dev \
+                gss-ntlmssp
     fi
 
     apt-get -y install gcc virtualenv python$IS3-{virtualenv,dev} cython$IS3
@@ -55,7 +56,8 @@ setup::fedora::install() {
 }
 
 setup::rh::install() {
-    setup::rh::yuminst krb5-{devel,libs,server,workstation} which gcc findutils
+    setup::rh::yuminst krb5-{devel,libs,server,workstation} \
+                       which gcc findutils gssntlmssp
 
     if [ -f /etc/fedora-release ]; then
         setup::fedora::install

--- a/gssapi/raw/cython_converters.pyx
+++ b/gssapi/raw/cython_converters.pyx
@@ -29,6 +29,13 @@ cdef gss_OID_set c_get_mech_oid_set(object mechs):
 cdef object c_create_oid_set(gss_OID_set mech_set, bint free=True):
     """Convert a GSS OID set struct to a set of OIDs"""
 
+    if mech_set == GSS_C_NO_OID_SET:
+        # return the empty set if the we get passed the C equivalent
+        # (it could be argued that the C equivalent is closer to None,
+        # but returning None would make the API harder to work with,
+        # without much value)
+        return set()
+
     py_set = set()
     cdef i
     for i in range(mech_set.count):

--- a/gssapi/tests/test_raw.py
+++ b/gssapi/tests/test_raw.py
@@ -668,10 +668,8 @@ class TestBaseUtilities(_GSSAPIKerberosTestCase):
             known_mech_attrs = inquire_out.known_mech_attrs
 
             mech_attrs.should_be_a(set)
-            mech_attrs.shouldnt_be_empty()
 
             known_mech_attrs.should_be_a(set)
-            known_mech_attrs.shouldnt_be_empty()
 
             # Verify that we get data for every available
             # attribute. Testing the contents of a few known
@@ -749,12 +747,10 @@ class TestBaseUtilities(_GSSAPIKerberosTestCase):
             out_mn = out.mech_name
             out_mn.shouldnt_be_none()
             out_mn.should_be_a(bytes)
-            out_mn.shouldnt_be_empty()
 
             out_md = out.mech_description
             out_md.shouldnt_be_none()
             out_md.should_be_a(bytes)
-            out_md.shouldnt_be_empty()
 
             cmp_mech = gb.inquire_mech_for_saslname(out_smn)
             cmp_mech.shouldnt_be_none()


### PR DESCRIPTION
Some methods can return GSS_C_NO_OID_SET on success, so we should handle
that in our set converter by returning the empty set.

Fixes #148