### PR TITLE
Rename m_ arguments to _attrs in gssapi/mechs.py

### DIFF
--- a/gssapi/mechs.py
+++ b/gssapi/mechs.py
@@ -164,15 +164,16 @@ class Mechanism(roids.OID):
         return cls(m)
 
     @classmethod
-    def from_attrs(cls, m_desired=None, m_except=None, m_critical=None):
+    def from_attrs(cls, desired_attrs=None, except_attrs=None,
+                   critical_attrs=None):
         """
         Get a generator of mechanisms supporting the specified attributes. See
         RFC 5587's :func:`indicate_mechs_by_attrs` for more information.
 
         Args:
-            m_desired ([OID]): Desired attributes
-            m_except ([OID]): Except attributes
-            m_critical ([OID]): Critical attributes
+            desired_attrs ([OID]): Desired attributes
+            except_attrs ([OID]): Except attributes
+            critical_attrs ([OID]): Critical attributes
 
         Returns:
             [Mechanism]: A set of mechanisms having the desired features.
@@ -182,18 +183,18 @@ class Mechanism(roids.OID):
 
         :requires-ext:`rfc5587`
         """
-        if isinstance(m_desired, roids.OID):
-            m_desired = set([m_desired])
-        if isinstance(m_except, roids.OID):
-            m_except = set([m_except])
-        if isinstance(m_critical, roids.OID):
-            m_critical = set([m_critical])
+        if isinstance(desired_attrs, roids.OID):
+            desired_attrs = set([desired_attrs])
+        if isinstance(except_attrs, roids.OID):
+            except_attrs = set([except_attrs])
+        if isinstance(critical_attrs, roids.OID):
+            critical_attrs = set([critical_attrs])
 
         if rfc5587 is None:
             raise NotImplementedError("Your GSSAPI implementation does not "
                                       "have support for RFC 5587")
 
-        mechs = rfc5587.indicate_mechs_by_attrs(m_desired,
-                                                m_except,
-                                                m_critical)
+        mechs = rfc5587.indicate_mechs_by_attrs(desired_attrs,
+                                                except_attrs,
+                                                critical_attrs)
         return (cls(mech) for mech in mechs)

--- a/gssapi/tests/test_high_level.py
+++ b/gssapi/tests/test_high_level.py
@@ -400,13 +400,16 @@ class MechsTestCase(_GSSAPIKerberosTestCase):
     def test_mech_inquiry(self):
         mechs = list(gssmechs.Mechanism.all_mechs())
         c = len(mechs)
+
+        g_M_from_attrs = gssmechs.Mechanism.from_attrs
+
         for mech in mechs:
             attrs = mech.attrs
             known_attrs = mech.known_attrs
 
             for attr in attrs:
-                from_desired = gssmechs.Mechanism.from_attrs(m_desired=[attr])
-                from_except = gssmechs.Mechanism.from_attrs(m_except=[attr])
+                from_desired = g_M_from_attrs(desired_attrs=[attr])
+                from_except = g_M_from_attrs(except_attrs=[attr])
 
                 from_desired = list(from_desired)
                 from_except = list(from_except)
@@ -416,8 +419,8 @@ class MechsTestCase(_GSSAPIKerberosTestCase):
                 from_except.shouldnt_include(mech)
 
             for attr in known_attrs:
-                from_desired = gssmechs.Mechanism.from_attrs(m_desired=[attr])
-                from_except = gssmechs.Mechanism.from_attrs(m_except=[attr])
+                from_desired = g_M_from_attrs(desired_attrs=[attr])
+                from_except = g_M_from_attrs(except_attrs=[attr])
 
                 from_desired = list(from_desired)
                 from_except = list(from_except)


### PR DESCRIPTION
Signed-off-by: Alexander Scheel <ascheel@redhat.com>

This was requested by @DirectXMan12.

Renames the `m_` arguments in `from_attrs` to use `_attrs` instead. Some prefix/suffix is required as `except` is a keyword in Python. However, `m_` was originally chosen as it matched the RFC but isn't descriptive. `_attrs` is more descriptive. As this hasn't been part of a release yet, renaming these arguments should be fine.