### PR TITLE
Support empty values in gss_key_value_set_desc

### DIFF
--- a/gssapi/raw/ext_cred_store.pyx
+++ b/gssapi/raw/ext_cred_store.pyx
@@ -83,7 +83,8 @@ cdef gss_key_value_set_desc* c_create_key_value_set(dict values) except NULL:
 
     for (i, (k, v)) in enumerate(values.items()):
         res.elements[i].key = k
-        res.elements[i].value = v
+        if v:
+            res.elements[i].value = v
 
     return res
 


### PR DESCRIPTION
Effectively, this performs the None -> NULL transformation between Python and
C.  Currently both MIT krb5 and Heimdal will both treat NULL as an unspecified
value, which causes it to be skipped.

Resolves: #182