### PR TITLE
Fix Loading DLL on Windows Python >=3.8

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -30,19 +30,15 @@ fi
 python setup.py build_ext --inplace $EXTRA_BUILDEXT
 BUILD_RES=$?
 
-if [ x"$KRB5_VER" = "xheimdal" ]; then
-    # heimdal can't run the tests yet, so just exit
-    exit $BUILD_RES
-fi
-
-if [ "$TRAVIS_OS_NAME" == "windows" ]; then
-    # Windows can't run tests yet, so just exit
-    exit $BUILD_RES
-fi
-
 if [ $BUILD_RES -ne 0 ]; then
     # if the build failed, don't run the tests
     exit $BUILD_RES
+fi
+
+if [ x"$KRB5_VER" = "xheimdal" ] || [ "$TRAVIS_OS_NAME" = "windows" ]; then
+    # heimdal/Windows can't run the tests yet, so just make sure it imports and exit
+    python -c "import gssapi"
+    exit $?
 fi
 
 python setup.py nosetests --verbosity=3

--- a/gssapi/_win_config.py
+++ b/gssapi/_win_config.py
@@ -7,6 +7,7 @@ down the import tree.
 """
 
 import os
+import shutil
 import ctypes
 
 #: Path to normal KfW installed bin folder
@@ -18,8 +19,8 @@ KFW_BIN = os.path.join(
 KFW_DL = "https://web.mit.edu/KERBEROS/dist"
 
 
-def k4w_in_path():
-    """Return if the main GSSAPI DLL for KfW is available in the PATH"""
+def kfw_available():
+    """Return if the main GSSAPI DLL for KfW can be loaded"""
     try:  # to load the main GSSAPI DLL
         ctypes.WinDLL('gssapi64.dll')
     except OSError:  # DLL is not in PATH
@@ -41,14 +42,31 @@ def error_not_found():
 def configure_windows():
     """
     Validate that KfW appears to be installed correctly and add it to the
-    PATH if necessary. In the case that it can't be located, raise an error.
+    DLL directories/PATH if necessary. In the case that it can't be located,
+    raise an error.
     """
-    if k4w_in_path():
+    if kfw_available():
         return  # All set, necessary DLLs should be available
+
     if os.path.exists(KFW_BIN):  # In standard location
-        os.environ['PATH'] += os.pathsep + KFW_BIN
-        if k4w_in_path():
+        try:  # to use Python 3.8's DLL handling
+            os.add_dll_directory(KFW_BIN)
+        except AttributeError:  # <3.8, use PATH
+            os.environ['PATH'] += os.pathsep + KFW_BIN
+        if kfw_available():
             return
+
+    # Check if kinit is in the PATH which should lead us to the bin folder
+    kinit_path = shutil.which('kinit')  # KfW provided binary
+    if kinit_path:  # Non-standard install location
+        try:  # Most likely >=3.8, otherwise it would have been found already
+            os.add_dll_directory(os.path.dirname(kinit_path))
+        except AttributeError:  # <3.8, corrupted installation?
+            pass
+        else:
+            if kfw_available():
+                return
+
     error_not_found()
 
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,3 +5,4 @@ shouldbe
 six
 Cython
 k5test
+decorator


### PR DESCRIPTION
As discussed in #193, Python 3.8 no longer searches the PATH for DLLs on Windows and instead looks in standard locations. I've updated the Windows compatibility handling to account for this and use the new `os.add_dll_directory()` when possible.

I also modified the tests to at least make sure the library can be imported on systems that we can't test on.  This would have failed the 3.8 build last release and caught the issue earlier.