### PR TITLE
Raise exception on unknown usage

### DIFF
--- a/gssapi/raw/creds.pyx
+++ b/gssapi/raw/creds.pyx
@@ -131,8 +131,11 @@ def acquire_cred(Name name=None, lifetime=None, mechs=None, usage='both'):
         c_usage = GSS_C_INITIATE
     elif usage == 'accept':
         c_usage = GSS_C_ACCEPT
-    else:
+    elif usage == 'both':
         c_usage = GSS_C_BOTH
+    else:
+        raise ValueError(f'Invalid usage "{usage}" - permitted values are '
+                         '"initiate", "accept", and "both"')
 
     cdef gss_cred_id_t creds
     cdef gss_OID_set actual_mechs
@@ -227,8 +230,11 @@ accept_lifetime=None, mutate_input=False)
         c_usage = GSS_C_INITIATE
     elif usage == 'accept':
         c_usage = GSS_C_ACCEPT
-    else:  # usage == 'both'
+    elif usage == 'both':
         c_usage = GSS_C_BOTH
+    else:
+        raise ValueError(f'Invalid usage "{usage}" - permitted values are '
+                         '"initiate", "accept", and "both"')
 
     cdef gss_cred_id_t raw_input_cred
     if input_cred is not None:

--- a/gssapi/raw/ext_cred_store.pyx
+++ b/gssapi/raw/ext_cred_store.pyx
@@ -147,8 +147,11 @@ usage='both')
         c_usage = GSS_C_INITIATE
     elif usage == 'accept':
         c_usage = GSS_C_ACCEPT
-    else:
+    elif usage == 'both':
         c_usage = GSS_C_BOTH
+    else:
+        raise ValueError(f'Invalid usage "{usage}" - permitted values are '
+                         '"initiate", "accept", and "both"')
 
     cdef gss_key_value_set_desc *c_store
     if store is not None:
@@ -232,8 +235,11 @@ init_lifetime=None, accept_lifetime=None)
         c_usage = GSS_C_INITIATE
     elif usage == 'accept':
         c_usage = GSS_C_ACCEPT
-    else:
+    elif usage == 'both':
         c_usage = GSS_C_BOTH
+    else:
+        raise ValueError(f'Invalid usage "{usage}" - permitted values are '
+                         '"initiate", "accept", and "both"')
 
     cdef gss_name_t c_name = name.raw_name
     cdef gss_OID c_mech = &mech.raw_oid
@@ -325,8 +331,11 @@ set_default=False)
         c_usage = GSS_C_INITIATE
     elif usage == 'accept':
         c_usage = GSS_C_ACCEPT
-    else:
+    elif usage == 'both':
         c_usage = GSS_C_BOTH
+    else:
+        raise ValueError(f'Invalid usage "{usage}" - permitted values are '
+                         '"initiate", "accept", and "both"')
 
     cdef gss_key_value_set_desc *c_store
     if store is not None:

--- a/gssapi/raw/ext_password.pyx
+++ b/gssapi/raw/ext_password.pyx
@@ -74,8 +74,11 @@ usage="initiate")
         c_usage = GSS_C_INITIATE
     elif usage == "accept":
         c_usage = GSS_C_ACCEPT
-    else:
+    elif usage == 'both':
         c_usage = GSS_C_BOTH
+    else:
+        raise ValueError(f'Invalid usage "{usage}" - permitted values are '
+                         '"initiate", "accept", and "both"')
 
     cdef gss_cred_id_t creds
     cdef gss_OID_set actual_mechs

--- a/gssapi/raw/ext_password_add.pyx
+++ b/gssapi/raw/ext_password_add.pyx
@@ -78,8 +78,11 @@ usage='initiate', init_lifetime=None, accept_lifetime=None)
         c_usage = GSS_C_INITIATE
     elif usage == "accept":
         c_usage = GSS_C_ACCEPT
-    else:
+    elif usage == 'both':
         c_usage = GSS_C_BOTH
+    else:
+        raise ValueError(f'Invalid usage "{usage}" - permitted values are '
+                         '"initiate", "accept", and "both"')
 
     cdef OM_uint32 input_initiator_ttl = c_py_ttl_to_c(init_lifetime)
     cdef OM_uint32 input_acceptor_ttl = c_py_ttl_to_c(accept_lifetime)

--- a/gssapi/raw/ext_rfc5588.pyx
+++ b/gssapi/raw/ext_rfc5588.pyx
@@ -63,8 +63,11 @@ set_default=False)
         c_usage = GSS_C_INITIATE
     elif usage == 'accept':
         c_usage = GSS_C_ACCEPT
-    else:
+    elif usage == 'both':
         c_usage = GSS_C_BOTH
+    else:
+        raise ValueError(f'Invalid usage "{usage}" - permitted values are '
+                         '"initiate", "accept", and "both"')
 
     cdef gss_cred_id_t c_creds = creds.raw_creds
 

--- a/gssapi/raw/ext_s4u.pyx
+++ b/gssapi/raw/ext_s4u.pyx
@@ -84,8 +84,11 @@ mechs=None, usage='initiate')
         c_usage = GSS_C_INITIATE
     elif usage == 'accept':
         c_usage = GSS_C_ACCEPT
-    else:
+    elif usage == 'both':
         c_usage = GSS_C_BOTH
+    else:
+        raise ValueError(f'Invalid usage "{usage}" - permitted values are '
+                         '"initiate", "accept", and "both"')
 
     cdef gss_cred_id_t creds
     cdef gss_OID_set actual_mechs
@@ -162,8 +165,11 @@ usage='initiate', init_lifetime=None, accept_lifetime=None)
         c_usage = GSS_C_INITIATE
     elif usage == 'accept':
         c_usage = GSS_C_ACCEPT
-    else:
+    elif usage == 'both':
         c_usage = GSS_C_BOTH
+    else:
+        raise ValueError(f'Invalid usage "{usage}" - permitted values are '
+                         '"initiate", "accept", and "both"')
 
     cdef gss_cred_id_t raw_input_cred
     if input_cred is not None:


### PR DESCRIPTION
Previously, we defaulted to conservatively assuming BOTH for usage type
when it wasn't obviously INITIATE or ACCEPT.  In most simple cases, this
will cause invalid values to behave as the user intended.  However, it
may cause mysterious failures in more complex cases.  Err on the side of
caution and raise ValueError when we can't determine the intented usage.

Resolves: #202