### PR TITLE
Handle missing locale.LC_MESSAGES enum on Windows

### DIFF
--- a/gssapi/raw/misc.pyx
+++ b/gssapi/raw/misc.pyx
@@ -291,7 +291,10 @@ class GSSError(Exception, metaclass=GSSErrorRegistry):
                 given code
         """
 
-        msg_encoding = locale.getlocale(locale.LC_MESSAGES)[1] or 'UTF-8'
+        try:
+            msg_encoding = locale.getlocale(locale.LC_MESSAGES)[1] or 'UTF-8'
+        except AttributeError:  # Windows doesn't have LC_MESSAGES
+            msg_encoding = 'UTF-8'
 
         res = []
         try:


### PR DESCRIPTION
PR for issue found in https://github.com/pythongssapi/httpx-gssapi/issues/2. Windows doesn't have the `LC_MESSAGES` constant in its `locale` library, so just fallback to UTF-8.