### PR TITLE
tests: Drop dependency on python-should_be

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@
                 "fail-fast": false,
                 "matrix": {
                     "name": ["debian-stable", "debian-heimdal", "centos-8",
-                             "fedora-31"],
+                             "fedora-latest"],
                     "include": [
                         {
                             "name": "debian-stable",
@@ -31,8 +31,8 @@
                             "distro": "centos:8",
                         },
                         {
-                            "name": "fedora-31",
-                            "distro": "fedora:31",
+                            "name": "fedora-latest",
+                            "distro": "fedora:latest",
                             "flake": "yes",
                         },
                     ],

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -12,7 +12,7 @@
                 {
                     "name": "Build docs",
                     "run": "./ci/run-on-linux.sh ./ci/before-docs-deploy.sh",
-                    "env": { "DISTRO": "fedora:31" },
+                    "env": { "DISTRO": "fedora:latest" },
                 },
                 {
                     "name": "Deploy latest docs",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@
                 {
                     "name": "Set things up",
                     "run": "./ci/run-on-linux.sh ./ci/before-deploy.sh",
-                    "env": { "DISTRO": "fedora:31" },
+                    "env": { "DISTRO": "fedora:latest" },
                 },
                 {
                     "name": "Deploy to PyPI",

--- a/gssapi/tests/test_high_level.py
+++ b/gssapi/tests/test_high_level.py
@@ -4,7 +4,6 @@ import socket
 import sys
 import pickle
 
-import should_be.all  # noqa
 import six
 from parameterized import parameterized
 
@@ -127,7 +126,7 @@ class CredsTestCase(_GSSAPIKerberosTestCase):
     def test_acquire_by_init(self, str_name, kwargs):
         creds = gsscreds.Credentials(name=self.name, **kwargs)
 
-        creds.lifetime.should_be_an_integer()
+        self.assertIsInstance(creds.lifetime, int)
 
         del creds
 
@@ -137,17 +136,17 @@ class CredsTestCase(_GSSAPIKerberosTestCase):
         cred_resp = gsscreds.Credentials.acquire(name=self.name,
                                                  **kwargs)
 
-        cred_resp.shouldnt_be_none()
+        self.assertIsNotNone(cred_resp)
 
         (creds, actual_mechs, ttl) = cred_resp
 
-        creds.shouldnt_be_none()
-        creds.should_be_a(gsscreds.Credentials)
+        self.assertIsNotNone(creds)
+        self.assertIsInstance(creds, gsscreds.Credentials)
 
-        actual_mechs.shouldnt_be_empty()
-        actual_mechs.should_include(gb.MechType.kerberos)
+        self.assertTrue(actual_mechs)
+        self.assertIn(gb.MechType.kerberos, actual_mechs)
 
-        ttl.should_be_an_integer()
+        self.assertIsInstance(ttl, int)
 
         del creds
 
@@ -172,16 +171,16 @@ class CredsTestCase(_GSSAPIKerberosTestCase):
         server_ctx.step(client_token)
 
         deleg_creds = server_ctx.delegated_creds
-        deleg_creds.shouldnt_be_none()
+        self.assertIsNotNone(deleg_creds)
 
         store_res = deleg_creds.store(usage='initiate', set_default=True,
                                       overwrite=True)
-        store_res.usage.should_be('initiate')
-        store_res.mechs.should_include(gb.MechType.kerberos)
+        self.assertEqual(store_res.usage, 'initiate')
+        self.assertIn(gb.MechType.kerberos, store_res.mechs)
 
         reacquired_creds = gsscreds.Credentials(name=deleg_creds.name,
                                                 usage='initiate')
-        reacquired_creds.shouldnt_be_none()
+        self.assertIsNotNone(reacquired_creds)
 
     @ktu.gssapi_extension_test('cred_store', 'credentials store')
     def test_store_into_acquire_from(self):
@@ -199,20 +198,20 @@ class CredsTestCase(_GSSAPIKerberosTestCase):
 
         store_res = initial_creds.store(store, overwrite=True)
 
-        store_res.mechs.shouldnt_be_none()
-        store_res.mechs.shouldnt_be_empty()
-        store_res.usage.should_be('initiate')
+        self.assertIsNotNone(store_res.mechs)
+        self.assertTrue(store_res.mechs)
+        self.assertEqual(store_res.usage, 'initiate')
 
         name = gssnames.Name(princ_name)
         retrieved_creds = gsscreds.Credentials(name=name, store=store)
 
-        retrieved_creds.shouldnt_be_none()
+        self.assertIsNotNone(retrieved_creds)
 
     def test_create_from_other(self):
         raw_creds = gb.acquire_cred(None, usage='accept').creds
 
         high_level_creds = gsscreds.Credentials(raw_creds)
-        high_level_creds.usage.should_be('accept')
+        self.assertEqual(high_level_creds.usage, 'accept')
 
     @true_false_perms('name', 'lifetime', 'usage', 'mechs')
     def test_inquire(self, str_name, kwargs):
@@ -220,25 +219,25 @@ class CredsTestCase(_GSSAPIKerberosTestCase):
         resp = creds.inquire(**kwargs)
 
         if kwargs['name']:
-            resp.name.should_be(self.name)
+            self.assertEqual(resp.name, self.name)
         else:
-            resp.name.should_be_none()
+            self.assertIsNone(resp.name)
 
         if kwargs['lifetime']:
-            resp.lifetime.should_be_an_integer()
+            self.assertIsInstance(resp.lifetime, int)
         else:
-            resp.lifetime.should_be_none()
+            self.assertIsNone(resp.lifetime)
 
         if kwargs['usage']:
-            resp.usage.should_be('both')
+            self.assertEqual(resp.usage, 'both')
         else:
-            resp.usage.should_be_none()
+            self.assertIsNone(resp.usage)
 
         if kwargs['mechs']:
-            resp.mechs.shouldnt_be_empty()
-            resp.mechs.should_include(gb.MechType.kerberos)
+            self.assertTrue(resp.mechs)
+            self.assertIn(gb.MechType.kerberos, resp.mechs)
         else:
-            resp.mechs.should_be_none()
+            self.assertIsNone(resp.mechs)
 
     @true_false_perms('name', 'init_lifetime', 'accept_lifetime', 'usage')
     def test_inquire_by_mech(self, str_name, kwargs):
@@ -246,24 +245,24 @@ class CredsTestCase(_GSSAPIKerberosTestCase):
         resp = creds.inquire_by_mech(mech=gb.MechType.kerberos, **kwargs)
 
         if kwargs['name']:
-            resp.name.should_be(self.name)
+            self.assertEqual(resp.name, self.name)
         else:
-            resp.name.should_be_none()
+            self.assertIsNone(resp.name)
 
         if kwargs['init_lifetime']:
-            resp.init_lifetime.should_be_an_integer()
+            self.assertIsInstance(resp.init_lifetime, int)
         else:
-            resp.init_lifetime.should_be_none()
+            self.assertIsNone(resp.init_lifetime)
 
         if kwargs['accept_lifetime']:
-            resp.accept_lifetime.should_be_an_integer()
+            self.assertIsInstance(resp.accept_lifetime, int)
         else:
-            resp.accept_lifetime.should_be_none()
+            self.assertIsNone(resp.accept_lifetime)
 
         if kwargs['usage']:
-            resp.usage.should_be('both')
+            self.assertEqual(resp.usage, 'both')
         else:
-            resp.usage.should_be_none()
+            self.assertIsNone(resp.usage)
 
     def test_add(self):
         input_creds = gsscreds.Credentials(gb.Creds())
@@ -271,8 +270,8 @@ class CredsTestCase(_GSSAPIKerberosTestCase):
         new_creds = input_creds.add(name, gb.MechType.kerberos,
                                     usage='initiate')
 
-        new_creds.shouldnt_be_none()
-        new_creds.should_be_a(gsscreds.Credentials)
+        self.assertIsNotNone(new_creds)
+        self.assertIsInstance(new_creds, gsscreds.Credentials)
 
     @ktu.gssapi_extension_test('cred_store', 'credentials store')
     def test_store_into_add_from(self):
@@ -290,23 +289,23 @@ class CredsTestCase(_GSSAPIKerberosTestCase):
 
         store_res = initial_creds.store(store, overwrite=True)
 
-        store_res.mechs.shouldnt_be_none()
-        store_res.mechs.shouldnt_be_empty()
-        store_res.usage.should_be('initiate')
+        self.assertIsNotNone(store_res.mechs)
+        self.assertTrue(store_res.mechs)
+        self.assertEqual(store_res.usage, 'initiate')
 
         name = gssnames.Name(princ_name)
         input_creds = gsscreds.Credentials(gb.Creds())
         retrieved_creds = input_creds.add(name, gb.MechType.kerberos,
                                           store=store)
 
-        retrieved_creds.shouldnt_be_none()
-        retrieved_creds.should_be_a(gsscreds.Credentials)
+        self.assertIsNotNone(retrieved_creds)
+        self.assertIsInstance(retrieved_creds, gsscreds.Credentials)
 
     @ktu.gssapi_extension_test('cred_imp_exp', 'credentials import-export')
     def test_export(self):
         creds = gsscreds.Credentials(name=self.name)
         token = creds.export()
-        token.should_be_a(bytes)
+        self.assertIsInstance(token, bytes)
 
     @ktu.gssapi_extension_test('cred_imp_exp', 'credentials import-export')
     def test_import_by_init(self):
@@ -314,8 +313,8 @@ class CredsTestCase(_GSSAPIKerberosTestCase):
         token = creds.export()
         imported_creds = gsscreds.Credentials(token=token)
 
-        imported_creds.lifetime.should_be(creds.lifetime)
-        imported_creds.name.should_be(creds.name)
+        self.assertEqual(imported_creds.lifetime, creds.lifetime)
+        self.assertEqual(imported_creds.name, creds.name)
 
     @ktu.gssapi_extension_test('cred_imp_exp', 'credentials import-export')
     def test_pickle_unpickle(self):
@@ -323,8 +322,8 @@ class CredsTestCase(_GSSAPIKerberosTestCase):
         pickled_creds = pickle.dumps(creds)
         unpickled_creds = pickle.loads(pickled_creds)
 
-        unpickled_creds.lifetime.should_be(creds.lifetime)
-        unpickled_creds.name.should_be(creds.name)
+        self.assertEqual(unpickled_creds.lifetime, creds.lifetime)
+        self.assertEqual(unpickled_creds.name, creds.name)
 
     @exist_perms(lifetime=30, mechs=[gb.MechType.kerberos],
                  usage='initiate')
@@ -345,8 +344,8 @@ class CredsTestCase(_GSSAPIKerberosTestCase):
 
         imp_creds = server_creds.impersonate(server_ctx_resp[1], **kwargs)
 
-        imp_creds.shouldnt_be_none()
-        imp_creds.should_be_a(gsscreds.Credentials)
+        self.assertIsNotNone(imp_creds)
+        self.assertIsInstance(imp_creds, gsscreds.Credentials)
 
     @ktu.gssapi_extension_test('s4u', 'S4U')
     def test_add_with_impersonate(self):
@@ -366,8 +365,8 @@ class CredsTestCase(_GSSAPIKerberosTestCase):
                                     impersonator=server_creds,
                                     usage='initiate')
 
-        new_creds.shouldnt_be(None)
-        new_creds.should_be_a(gsscreds.Credentials)
+        self.assertIsNotNone(new_creds)
+        self.assertIsInstance(new_creds, gsscreds.Credentials)
 
 
 class MechsTestCase(_GSSAPIKerberosTestCase):
@@ -375,26 +374,26 @@ class MechsTestCase(_GSSAPIKerberosTestCase):
         mechs = gssmechs.Mechanism.all_mechs()
         for mech in mechs:
             s = str(mech)
-            s.shouldnt_be_empty()
+            self.assertTrue(s)
 
     @ktu.gssapi_extension_test('rfc5801', 'RFC 5801: SASL Names')
     def test_sasl_properties(self):
         mechs = gssmechs.Mechanism.all_mechs()
         for mech in mechs:
             s = str(mech)
-            s.shouldnt_be_empty()
-            s.should_be_a(str)
+            self.assertTrue(s)
+            self.assertIsInstance(s, str)
 
             # Note that some mechanisms don't have SASL names or SASL
             # descriptions; in this case, GSSAPI returns empty strings.
             if mech.sasl_name:
-                mech.sasl_name.should_be_a(six.text_type)
+                self.assertIsInstance(mech.sasl_name, six.text_type)
 
             if mech.description:
-                mech.description.should_be_a(six.text_type)
+                self.assertIsInstance(mech.description, six.text_type)
 
             cmp_mech = gssmechs.Mechanism.from_sasl_name(mech.sasl_name)
-            str(cmp_mech).should_be(str(mech))
+            self.assertEqual(str(cmp_mech), str(mech))
 
     @ktu.gssapi_extension_test('rfc5587', 'RFC 5587: Mech Inquiry')
     def test_mech_inquiry(self):
@@ -414,9 +413,9 @@ class MechsTestCase(_GSSAPIKerberosTestCase):
                 from_desired = list(from_desired)
                 from_except = list(from_except)
 
-                (len(from_desired) + len(from_except)).should_be(c)
-                from_desired.should_include(mech)
-                from_except.shouldnt_include(mech)
+                self.assertEqual(len(from_desired) + len(from_except), c)
+                self.assertIn(mech, from_desired)
+                self.assertNotIn(mech, from_except)
 
             for attr in known_attrs:
                 from_desired = g_M_from_attrs(desired_attrs=[attr])
@@ -425,7 +424,7 @@ class MechsTestCase(_GSSAPIKerberosTestCase):
                 from_desired = list(from_desired)
                 from_except = list(from_except)
 
-                (len(from_desired) + len(from_except)).should_be(c)
+                self.assertEqual(len(from_desired) + len(from_except), c)
 
 
 class NamesTestCase(_GSSAPIKerberosTestCase):
@@ -433,18 +432,18 @@ class NamesTestCase(_GSSAPIKerberosTestCase):
         raw_name = gb.import_name(SERVICE_PRINCIPAL)
         high_level_name = gssnames.Name(raw_name)
 
-        bytes(high_level_name).should_be(SERVICE_PRINCIPAL)
+        self.assertEqual(bytes(high_level_name), SERVICE_PRINCIPAL)
 
     def test_create_from_name_no_type(self):
         name = gssnames.Name(SERVICE_PRINCIPAL)
 
-        name.shouldnt_be_none()
+        self.assertIsNotNone(name)
 
     def test_create_from_name_and_type(self):
         name = gssnames.Name(SERVICE_PRINCIPAL, gb.NameType.kerberos_principal)
 
-        name.shouldnt_be_none()
-        name.name_type.should_be(gb.NameType.kerberos_principal)
+        self.assertIsNotNone(name)
+        self.assertEqual(name.name_type, gb.NameType.kerberos_principal)
 
     def test_create_from_token(self):
         name1 = gssnames.Name(TARGET_SERVICE_NAME,
@@ -452,8 +451,8 @@ class NamesTestCase(_GSSAPIKerberosTestCase):
         exported_name = name1.canonicalize(gb.MechType.kerberos).export()
         name2 = gssnames.Name(token=exported_name)
 
-        name2.shouldnt_be_none()
-        name2.name_type.should_be(gb.NameType.kerberos_principal)
+        self.assertIsNotNone(name2)
+        self.assertEqual(name2.name_type, gb.NameType.kerberos_principal)
 
     @ktu.gssapi_extension_test('rfc6680', 'RFC 6680')
     def test_display_as(self):
@@ -467,9 +466,9 @@ class NamesTestCase(_GSSAPIKerberosTestCase):
             gb.NameType.hostbased_service)
 
         princ_str = SERVICE_PRINCIPAL.decode('utf-8') + '@'
-        six.text_type(canonical_name).should_be(princ_str)
-        krb_name.should_be_a(six.text_type)
-        krb_name.should_be(princ_str)
+        self.assertEqual(six.text_type(canonical_name), princ_str)
+        self.assertIsInstance(krb_name, six.text_type)
+        self.assertEqual(krb_name, princ_str)
 
     @ktu.gssapi_extension_test('rfc6680', 'RFC 6680')
     def test_create_from_composite_token_no_attrs(self):
@@ -479,7 +478,7 @@ class NamesTestCase(_GSSAPIKerberosTestCase):
             gb.MechType.kerberos).export(composite=True)
         name2 = gssnames.Name(token=exported_name, composite=True)
 
-        name2.shouldnt_be_none()
+        self.assertIsNotNone(name2)
 
     @ktu.gssapi_extension_test('rfc6680', 'RFC 6680')
     @ktu.krb_plugin_test('authdata', 'greet_client')
@@ -503,33 +502,34 @@ class NamesTestCase(_GSSAPIKerberosTestCase):
 
         name2 = gssnames.Name(token=exported_name)
 
-        name2.shouldnt_be_none()
+        self.assertIsNotNone(name2)
 
-        name2.attributes['urn:greet:greeting'].values.should_be(
-            set([b'some val']))
-        name2.attributes['urn:greet:greeting'].complete.should_be_true()
-        name2.attributes['urn:greet:greeting'].authenticated.should_be_false()
+        self.assertEqual(name2.attributes['urn:greet:greeting'].values,
+                         set([b'some val']))
+        self.assertTrue(name2.attributes['urn:greet:greeting'].complete)
+        self.assertFalse(name2.attributes['urn:greet:greeting'].authenticated)
 
     def test_to_str(self):
         name = gssnames.Name(SERVICE_PRINCIPAL, gb.NameType.kerberos_principal)
 
         name_str = str(name)
 
-        name_str.should_be_a(str)
+        self.assertIsInstance(name_str, str)
         if sys.version_info[0] == 2:
             target_val = SERVICE_PRINCIPAL
         else:
             target_val = SERVICE_PRINCIPAL.decode(gssutils._get_encoding())
 
-        name_str.should_be(target_val)
+        self.assertEqual(name_str, target_val)
 
     def test_to_unicode(self):
         name = gssnames.Name(SERVICE_PRINCIPAL, gb.NameType.kerberos_principal)
 
         name_str = six.text_type(name)
 
-        name_str.should_be_a(six.text_type)
-        name_str.should_be(SERVICE_PRINCIPAL.decode(gssutils._get_encoding()))
+        self.assertIsInstance(name_str, six.text_type)
+        self.assertEqual(name_str,
+                         SERVICE_PRINCIPAL.decode(gssutils._get_encoding()))
 
     def test_to_bytes(self):
         name = gssnames.Name(SERVICE_PRINCIPAL, gb.NameType.kerberos_principal)
@@ -537,8 +537,8 @@ class NamesTestCase(_GSSAPIKerberosTestCase):
         # NB(directxman12): bytes only calles __bytes__ on Python 3+
         name_bytes = name.__bytes__()
 
-        name_bytes.should_be_a(bytes)
-        name_bytes.should_be(SERVICE_PRINCIPAL)
+        self.assertIsInstance(name_bytes, bytes)
+        self.assertEqual(name_bytes, SERVICE_PRINCIPAL)
 
     def test_compare(self):
         name1 = gssnames.Name(SERVICE_PRINCIPAL)
@@ -546,29 +546,29 @@ class NamesTestCase(_GSSAPIKerberosTestCase):
         name3 = gssnames.Name(TARGET_SERVICE_NAME,
                               gb.NameType.hostbased_service)
 
-        name1.should_be(name2)
-        name1.shouldnt_be(name3)
+        self.assertEqual(name1, name2)
+        self.assertNotEqual(name1, name3)
 
     def test_canoncialize_and_export(self):
         name = gssnames.Name(SERVICE_PRINCIPAL, gb.NameType.kerberos_principal)
         canonical_name = name.canonicalize(gb.MechType.kerberos)
         exported_name = canonical_name.export()
 
-        exported_name.should_be_a(bytes)
+        self.assertIsInstance(exported_name, bytes)
 
     def test_canonicalize(self):
         name = gssnames.Name(TARGET_SERVICE_NAME,
                              gb.NameType.hostbased_service)
 
         canonicalized_name = name.canonicalize(gb.MechType.kerberos)
-        canonicalized_name.should_be_a(gssnames.Name)
-        bytes(canonicalized_name).should_be(SERVICE_PRINCIPAL + b'@')
+        self.assertIsInstance(canonicalized_name, gssnames.Name)
+        self.assertEqual(bytes(canonicalized_name), SERVICE_PRINCIPAL + b'@')
 
     def test_copy(self):
         name1 = gssnames.Name(SERVICE_PRINCIPAL)
         name2 = copy.copy(name1)
 
-        name1.should_be(name2)
+        self.assertEqual(name1, name2)
 
     # NB(directxman12): we don't test display_name_ext because the krb5 mech
     # doesn't actually implement it
@@ -578,13 +578,13 @@ class NamesTestCase(_GSSAPIKerberosTestCase):
         name = gssnames.Name(TARGET_SERVICE_NAME,
                              gb.NameType.hostbased_service)
 
-        name.is_mech_name.should_be_false()
+        self.assertFalse(name.is_mech_name)
 
         canon_name = name.canonicalize(gb.MechType.kerberos)
 
-        canon_name.is_mech_name.should_be_true()
-        canon_name.mech.should_be_a(gb.OID)
-        canon_name.mech.should_be(gb.MechType.kerberos)
+        self.assertTrue(canon_name.is_mech_name)
+        self.assertIsInstance(canon_name.mech, gb.OID)
+        self.assertEqual(canon_name.mech, gb.MechType.kerberos)
 
     @ktu.gssapi_extension_test('rfc6680', 'RFC 6680')
     def test_export_name_composite_no_attrs(self):
@@ -593,7 +593,7 @@ class NamesTestCase(_GSSAPIKerberosTestCase):
         canon_name = name.canonicalize(gb.MechType.kerberos)
         exported_name = canon_name.export(composite=True)
 
-        exported_name.should_be_a(bytes)
+        self.assertIsInstance(exported_name, bytes)
 
     @ktu.gssapi_extension_test('rfc6680', 'RFC 6680')
     @ktu.krb_plugin_test('authdata', 'greet_client')
@@ -604,7 +604,7 @@ class NamesTestCase(_GSSAPIKerberosTestCase):
         canon_name.attributes['urn:greet:greeting'] = b'some val'
         exported_name = canon_name.export(composite=True)
 
-        exported_name.should_be_a(bytes)
+        self.assertIsInstance(exported_name, bytes)
 
     @ktu.gssapi_extension_test('rfc6680', 'RFC 6680')
     @ktu.krb_plugin_test('authdata', 'greet_client')
@@ -614,11 +614,11 @@ class NamesTestCase(_GSSAPIKerberosTestCase):
         canon_name = name.canonicalize(gb.MechType.kerberos)
 
         canon_name.attributes['urn:greet:greeting'] = (b'some val', True)
-        canon_name.attributes['urn:greet:greeting'].values.should_be(
-            set([b'some val']))
-        canon_name.attributes['urn:greet:greeting'].complete.should_be_true()
-        (canon_name.attributes['urn:greet:greeting'].authenticated
-            .should_be_false())
+        self.assertEqual(canon_name.attributes['urn:greet:greeting'].values,
+                         set([b'some val']))
+        self.assertTrue(canon_name.attributes['urn:greet:greeting'].complete)
+        self.assertFalse(
+            canon_name.attributes['urn:greet:greeting'].authenticated)
 
         del canon_name.attributes['urn:greet:greeting']
 
@@ -626,7 +626,7 @@ class NamesTestCase(_GSSAPIKerberosTestCase):
         # doesn't properly delete itself -- it just clears the value
         # If we try to get its value now, we segfault (due to an issue with
         # greet:greeting's delete).  Instead, just try setting the value again
-        # canon_name.attributes.should_be_empty(), which would normally give
+        # self.assertFalse(canon_name.attributes), which would normally give
         # an error.
         canon_name.attributes['urn:greet:greeting'] = b'some other val'
 
@@ -656,7 +656,7 @@ class SecurityContextTestCase(_GSSAPIKerberosTestCase):
     def test_create_from_other(self):
         raw_client_ctx, raw_server_ctx = self._create_completed_contexts()
         high_level_ctx = gssctx.SecurityContext(raw_client_ctx)
-        high_level_ctx.target_name.should_be(self.target_name)
+        self.assertEqual(high_level_ctx.target_name, self.target_name)
 
     @exist_perms(lifetime=30, flags=[],
                  mech=gb.MechType.kerberos,
@@ -665,30 +665,30 @@ class SecurityContextTestCase(_GSSAPIKerberosTestCase):
         client_ctx = gssctx.SecurityContext(name=self.target_name,
                                             creds=self.client_creds,
                                             **kwargs)
-        client_ctx.usage.should_be('initiate')
+        self.assertEqual(client_ctx.usage, 'initiate')
 
         client_ctx = self._create_client_ctx(**kwargs)
-        client_ctx.usage.should_be('initiate')
+        self.assertEqual(client_ctx.usage, 'initiate')
 
     def test_create_new_accept(self):
         server_ctx = gssctx.SecurityContext(creds=self.server_creds)
-        server_ctx.usage.should_be('accept')
+        self.assertEqual(server_ctx.usage, 'accept')
 
     def test_init_throws_error_on_invalid_args(self):
         def create_sec_context():
             gssctx.SecurityContext(usage='accept', name=self.target_name)
 
-        create_sec_context.should_raise(TypeError)
+        self.assertRaises(TypeError, create_sec_context)
 
     def _create_completed_contexts(self):
         client_ctx = self._create_client_ctx(lifetime=400)
 
         client_token = client_ctx.step()
-        client_token.should_be_a(bytes)
+        self.assertIsInstance(client_token, bytes)
 
         server_ctx = gssctx.SecurityContext(creds=self.server_creds)
         server_token = server_ctx.step(client_token)
-        server_token.should_be_a(bytes)
+        self.assertIsInstance(server_token, bytes)
 
         client_ctx.step(server_token)
 
@@ -697,33 +697,33 @@ class SecurityContextTestCase(_GSSAPIKerberosTestCase):
     def test_complete_on_partially_completed(self):
         client_ctx = self._create_client_ctx()
         client_tok = client_ctx.step()
-        client_ctx.complete.should_be_false()
+        self.assertFalse(client_ctx.complete)
 
         server_ctx = gssctx.SecurityContext(creds=self.server_creds)
         server_tok = server_ctx.step(client_tok)
 
         client_ctx.step(server_tok)
 
-        client_ctx.complete.should_be_true()
-        server_ctx.complete.should_be_true()
+        self.assertTrue(client_ctx.complete)
+        self.assertTrue(server_ctx.complete)
 
     def test_initiate_accept_steps(self):
         client_ctx, server_ctx = self._create_completed_contexts()
 
         # KDC may allow for clockskew by increasing acceptor context lifetime
-        server_ctx.lifetime.should_be_at_most(400 + 300)
-        server_ctx.initiator_name.should_be(client_ctx.initiator_name)
-        server_ctx.mech.should_be_a(gb.OID)
-        server_ctx.actual_flags.should_be_a(gb.IntEnumFlagSet)
-        server_ctx.locally_initiated.should_be_false()
-        server_ctx.complete.should_be_true()
+        self.assertLessEqual(server_ctx.lifetime, 400 + 300)
+        self.assertEqual(server_ctx.initiator_name, client_ctx.initiator_name)
+        self.assertIsInstance(server_ctx.mech, gb.OID)
+        self.assertIsInstance(server_ctx.actual_flags, gb.IntEnumFlagSet)
+        self.assertFalse(server_ctx.locally_initiated)
+        self.assertTrue(server_ctx.complete)
 
-        client_ctx.lifetime.should_be_at_most(400)
-        client_ctx.target_name.should_be(self.target_name)
-        client_ctx.mech.should_be_a(gb.OID)
-        client_ctx.actual_flags.should_be_a(gb.IntEnumFlagSet)
-        client_ctx.locally_initiated.should_be_true()
-        client_ctx.complete.should_be_true()
+        self.assertLessEqual(client_ctx.lifetime, 400)
+        self.assertEqual(client_ctx.target_name, self.target_name)
+        self.assertIsInstance(client_ctx.mech, gb.OID)
+        self.assertIsInstance(client_ctx.actual_flags, gb.IntEnumFlagSet)
+        self.assertTrue(client_ctx.locally_initiated)
+        self.assertTrue(client_ctx.complete)
 
     def test_channel_bindings(self):
         bdgs = gb.ChannelBindings(application_data=b'abcxyz',
@@ -735,12 +735,12 @@ class SecurityContextTestCase(_GSSAPIKerberosTestCase):
                                              channel_bindings=bdgs)
 
         client_token = client_ctx.step()
-        client_token.should_be_a(bytes)
+        self.assertIsInstance(client_token, bytes)
 
         server_ctx = gssctx.SecurityContext(creds=self.server_creds,
                                             channel_bindings=bdgs)
         server_token = server_ctx.step(client_token)
-        server_token.should_be_a(bytes)
+        self.assertIsInstance(server_token, bytes)
 
         client_ctx.step(server_token)
 
@@ -754,23 +754,24 @@ class SecurityContextTestCase(_GSSAPIKerberosTestCase):
                                              channel_bindings=bdgs)
 
         client_token = client_ctx.step()
-        client_token.should_be_a(bytes)
+        self.assertIsInstance(client_token, bytes)
 
         bdgs.acceptor_address = b'127.0.1.0'
         server_ctx = gssctx.SecurityContext(creds=self.server_creds,
                                             channel_bindings=bdgs)
-        server_ctx.step.should_raise(gb.BadChannelBindingsError, client_token)
+        self.assertRaises(gb.BadChannelBindingsError, server_ctx.step,
+                          client_token)
 
     def test_export_create_from_token(self):
         client_ctx, server_ctx = self._create_completed_contexts()
         token = client_ctx.export()
 
-        token.should_be_a(bytes)
+        self.assertIsInstance(token, bytes)
 
         imported_ctx = gssctx.SecurityContext(token=token)
 
-        imported_ctx.usage.should_be('initiate')
-        imported_ctx.target_name.should_be(self.target_name)
+        self.assertEqual(imported_ctx.usage, 'initiate')
+        self.assertEqual(imported_ctx.target_name, self.target_name)
 
     def test_pickle_unpickle(self):
         client_ctx, server_ctx = self._create_completed_contexts()
@@ -778,44 +779,44 @@ class SecurityContextTestCase(_GSSAPIKerberosTestCase):
 
         unpickled_ctx = pickle.loads(pickled_ctx)
 
-        unpickled_ctx.should_be_a(gssctx.SecurityContext)
-        unpickled_ctx.usage.should_be('initiate')
-        unpickled_ctx.target_name.should_be(self.target_name)
+        self.assertIsInstance(unpickled_ctx, gssctx.SecurityContext)
+        self.assertEqual(unpickled_ctx.usage, 'initiate')
+        self.assertEqual(unpickled_ctx.target_name, self.target_name)
 
     def test_encrypt_decrypt(self):
         client_ctx, server_ctx = self._create_completed_contexts()
 
         encrypted_msg = client_ctx.encrypt(b'test message')
-        encrypted_msg.should_be_a(bytes)
+        self.assertIsInstance(encrypted_msg, bytes)
 
         decrypted_msg = server_ctx.decrypt(encrypted_msg)
-        decrypted_msg.should_be_a(bytes)
-        decrypted_msg.should_be(b'test message')
+        self.assertIsInstance(decrypted_msg, bytes)
+        self.assertEqual(decrypted_msg, b'test message')
 
     def test_encrypt_decrypt_throws_error_on_no_encryption(self):
         client_ctx, server_ctx = self._create_completed_contexts()
 
         wrap_res = client_ctx.wrap(b'test message', False)
-        wrap_res.should_be_a(gb.WrapResult)
-        wrap_res.encrypted.should_be_false()
-        wrap_res.message.should_be_a(bytes)
+        self.assertIsInstance(wrap_res, gb.WrapResult)
+        self.assertFalse(wrap_res.encrypted)
+        self.assertIsInstance(wrap_res.message, bytes)
 
-        server_ctx.decrypt.should_raise(excs.EncryptionNotUsed,
-                                        wrap_res.message)
+        self.assertRaises(excs.EncryptionNotUsed, server_ctx.decrypt,
+                          wrap_res.message)
 
     def test_wrap_unwrap(self):
         client_ctx, server_ctx = self._create_completed_contexts()
 
         wrap_res = client_ctx.wrap(b'test message', True)
-        wrap_res.should_be_a(gb.WrapResult)
-        wrap_res.encrypted.should_be_true()
-        wrap_res.message.should_be_a(bytes)
+        self.assertIsInstance(wrap_res, gb.WrapResult)
+        self.assertTrue(wrap_res.encrypted)
+        self.assertIsInstance(wrap_res.message, bytes)
 
         unwrap_res = server_ctx.unwrap(wrap_res.message)
-        unwrap_res.should_be_a(gb.UnwrapResult)
-        unwrap_res.message.should_be_a(bytes)
-        unwrap_res.message.should_be(b'test message')
-        unwrap_res.encrypted.should_be_true()
+        self.assertIsInstance(unwrap_res, gb.UnwrapResult)
+        self.assertIsInstance(unwrap_res.message, bytes)
+        self.assertEqual(unwrap_res.message, b'test message')
+        self.assertTrue(unwrap_res.encrypted)
 
     def test_get_wrap_size_limit(self):
         client_ctx, server_ctx = self._create_completed_contexts()
@@ -823,18 +824,18 @@ class SecurityContextTestCase(_GSSAPIKerberosTestCase):
         with_conf = client_ctx.get_wrap_size_limit(100)
         without_conf = client_ctx.get_wrap_size_limit(100, encrypted=True)
 
-        with_conf.should_be_an_integer()
-        without_conf.should_be_an_integer()
+        self.assertIsInstance(with_conf, int)
+        self.assertIsInstance(without_conf, int)
 
-        with_conf.should_be_at_most(100)
-        without_conf.should_be_at_most(100)
+        self.assertLessEqual(with_conf, 100)
+        self.assertLessEqual(without_conf, 100)
 
     def test_get_signature(self):
         client_ctx, server_ctx = self._create_completed_contexts()
         mic_token = client_ctx.get_signature(b'some message')
 
-        mic_token.should_be_a(bytes)
-        mic_token.shouldnt_be_empty()
+        self.assertIsInstance(mic_token, bytes)
+        self.assertTrue(mic_token)
 
     def test_verify_signature_raise(self):
         client_ctx, server_ctx = self._create_completed_contexts()
@@ -842,8 +843,8 @@ class SecurityContextTestCase(_GSSAPIKerberosTestCase):
 
         server_ctx.verify_signature(b'some message', mic_token)
 
-        server_ctx.verify_signature.should_raise(gb.GSSError,
-                                                 b'other message', mic_token)
+        self.assertRaises(gb.GSSError, server_ctx.verify_signature,
+                          b'other message', mic_token)
 
     @ktu.krb_minversion_test("1.11", "returning tokens")
     def test_defer_step_error_on_method(self):
@@ -853,13 +854,14 @@ class SecurityContextTestCase(_GSSAPIKerberosTestCase):
                                              channel_bindings=bdgs)
 
         client_token = client_ctx.step()
-        client_token.should_be_a(bytes)
+        self.assertIsInstance(client_token, bytes)
 
         bdgs.application_data = b'defuvw'
         server_ctx = gssctx.SecurityContext(creds=self.server_creds,
                                             channel_bindings=bdgs)
-        server_ctx.step(client_token).should_be_a(bytes)
-        server_ctx.encrypt.should_raise(gb.BadChannelBindingsError, b'test')
+        self.assertIsInstance(server_ctx.step(client_token), bytes)
+        self.assertRaises(gb.BadChannelBindingsError, server_ctx.encrypt,
+                          b'test')
 
     @ktu.krb_minversion_test("1.11", "returning tokens")
     def test_defer_step_error_on_complete_property_access(self):
@@ -869,14 +871,14 @@ class SecurityContextTestCase(_GSSAPIKerberosTestCase):
                                              channel_bindings=bdgs)
 
         client_token = client_ctx.step()
-        client_token.should_be_a(bytes)
+        self.assertIsInstance(client_token, bytes)
 
         bdgs.application_data = b'defuvw'
         server_ctx = gssctx.SecurityContext(creds=self.server_creds,
                                             channel_bindings=bdgs)
-        server_ctx.step(client_token).should_be_a(bytes)
+        self.assertIsInstance(server_ctx.step(client_token), bytes)
 
         def check_complete():
             return server_ctx.complete
 
-        check_complete.should_raise(gb.BadChannelBindingsError)
+        self.assertRaises(gb.BadChannelBindingsError, check_complete)

--- a/gssapi/tests/test_raw.py
+++ b/gssapi/tests/test_raw.py
@@ -4,7 +4,6 @@ import socket
 import unittest
 
 import six
-import should_be.all  # noqa
 
 import gssapi.raw as gb
 import gssapi.raw.misc as gbmisc
@@ -64,17 +63,17 @@ class TestBaseUtilities(_GSSAPIKerberosTestCase):
     def test_indicate_mechs(self):
         mechs = gb.indicate_mechs()
 
-        mechs.shouldnt_be_none()
-        mechs.should_be_a(set)
-        mechs.shouldnt_be_empty()
+        self.assertIsNotNone(mechs)
+        self.assertIsInstance(mechs, set)
+        self.assertTrue(mechs)
 
-        mechs.should_include(gb.MechType.kerberos)
+        self.assertIn(gb.MechType.kerberos, mechs)
 
     def test_import_name(self):
         imported_name = gb.import_name(TARGET_SERVICE_NAME)
 
-        imported_name.shouldnt_be_none()
-        imported_name.should_be_a(gb.Name)
+        self.assertIsNotNone(imported_name)
+        self.assertIsInstance(imported_name, gb.Name)
 
         gb.release_name(imported_name)
 
@@ -85,37 +84,37 @@ class TestBaseUtilities(_GSSAPIKerberosTestCase):
         canonicalized_name = gb.canonicalize_name(imported_name,
                                                   gb.MechType.kerberos)
 
-        canonicalized_name.shouldnt_be_none()
-        canonicalized_name.should_be_a(gb.Name)
+        self.assertIsNotNone(canonicalized_name)
+        self.assertIsInstance(canonicalized_name, gb.Name)
 
         exported_name = gb.export_name(canonicalized_name)
 
-        exported_name.shouldnt_be_none()
-        exported_name.should_be_a(bytes)
-        exported_name.shouldnt_be_empty()
+        self.assertIsNotNone(exported_name)
+        self.assertIsInstance(exported_name, bytes)
+        self.assertTrue(exported_name)
 
     def test_duplicate_name(self):
         orig_name = gb.import_name(TARGET_SERVICE_NAME)
         new_name = gb.duplicate_name(orig_name)
 
-        new_name.shouldnt_be_none()
-        gb.compare_name(orig_name, new_name).should_be_true()
+        self.assertIsNotNone(new_name)
+        self.assertTrue(gb.compare_name(orig_name, new_name))
 
     def test_display_name(self):
         imported_name = gb.import_name(TARGET_SERVICE_NAME,
                                        gb.NameType.hostbased_service)
         displ_resp = gb.display_name(imported_name)
 
-        displ_resp.shouldnt_be_none()
+        self.assertIsNotNone(displ_resp)
 
         (displayed_name, out_type) = displ_resp
 
-        displayed_name.shouldnt_be_none()
-        displayed_name.should_be_a(bytes)
-        displayed_name.should_be(TARGET_SERVICE_NAME)
+        self.assertIsNotNone(displayed_name)
+        self.assertIsInstance(displayed_name, bytes)
+        self.assertEqual(displayed_name, TARGET_SERVICE_NAME)
 
-        out_type.shouldnt_be_none()
-        out_type.should_be(gb.NameType.hostbased_service)
+        self.assertIsNotNone(out_type)
+        self.assertEqual(out_type, gb.NameType.hostbased_service)
 
     # NB(directxman12): we don't test display_name_ext because the krb5 mech
     # doesn't actually implement it
@@ -126,10 +125,10 @@ class TestBaseUtilities(_GSSAPIKerberosTestCase):
                                    gb.NameType.hostbased_service)
         inquire_res = gb.inquire_name(base_name)
 
-        inquire_res.shouldnt_be_none()
+        self.assertIsNotNone(inquire_res)
 
-        inquire_res.is_mech_name.should_be_false()
-        inquire_res.mech.should_be_none()
+        self.assertFalse(inquire_res.is_mech_name)
+        self.assertIsNone(inquire_res.mech)
 
     @ktu.gssapi_extension_test('rfc6680', 'RFC 6680')
     def test_inquire_name_mech_name(self):
@@ -138,11 +137,11 @@ class TestBaseUtilities(_GSSAPIKerberosTestCase):
         mech_name = gb.canonicalize_name(base_name, gb.MechType.kerberos)
 
         inquire_res = gb.inquire_name(mech_name)
-        inquire_res.shouldnt_be_none()
+        self.assertIsNotNone(inquire_res)
 
-        inquire_res.is_mech_name.should_be_true()
-        inquire_res.mech.should_be_a(gb.OID)
-        inquire_res.mech.should_be(gb.MechType.kerberos)
+        self.assertTrue(inquire_res.is_mech_name)
+        self.assertIsInstance(inquire_res.mech, gb.OID)
+        self.assertEqual(inquire_res.mech, gb.MechType.kerberos)
 
     @ktu.gssapi_extension_test('rfc6680', 'RFC 6680')
     @ktu.gssapi_extension_test('rfc6680_comp_oid',
@@ -155,12 +154,12 @@ class TestBaseUtilities(_GSSAPIKerberosTestCase):
                                           gb.MechType.kerberos)
         exported_name = gb.export_name_composite(canon_name)
 
-        exported_name.should_be_a(bytes)
+        self.assertIsInstance(exported_name, bytes)
 
         imported_name = gb.import_name(exported_name,
                                        gb.NameType.composite_export)
 
-        imported_name.should_be_a(gb.Name)
+        self.assertIsInstance(imported_name, gb.Name)
 
     # NB(directxman12): the greet_client plugin only allows for one value
 
@@ -174,10 +173,10 @@ class TestBaseUtilities(_GSSAPIKerberosTestCase):
                               [b'some greeting'])
 
         inquire_res = gb.inquire_name(canon_name)
-        inquire_res.shouldnt_be_none()
+        self.assertIsNotNone(inquire_res)
 
-        inquire_res.attrs.should_be_a(list)
-        inquire_res.attrs.should_be([b'urn:greet:greeting'])
+        self.assertIsInstance(inquire_res.attrs, list)
+        self.assertEqual(inquire_res.attrs, [b'urn:greet:greeting'])
 
     @ktu.gssapi_extension_test('rfc6680', 'RFC 6680')
     @ktu.krb_plugin_test('authdata', 'greet_client')
@@ -190,16 +189,16 @@ class TestBaseUtilities(_GSSAPIKerberosTestCase):
                               [b'some other val'], complete=True)
 
         get_res = gb.get_name_attribute(canon_name, b'urn:greet:greeting')
-        get_res.shouldnt_be_none()
+        self.assertIsNotNone(get_res)
 
-        get_res.values.should_be_a(list)
-        get_res.values.should_be([b'some other val'])
+        self.assertIsInstance(get_res.values, list)
+        self.assertEqual(get_res.values, [b'some other val'])
 
-        get_res.display_values.should_be_a(list)
-        get_res.display_values.should_be(get_res.values)
+        self.assertIsInstance(get_res.display_values, list)
+        self.assertEqual(get_res.display_values, get_res.values)
 
-        get_res.complete.should_be_true()
-        get_res.authenticated.should_be_false()
+        self.assertTrue(get_res.complete)
+        self.assertFalse(get_res.authenticated)
 
         gb.delete_name_attribute(canon_name, b'urn:greet:greeting')
 
@@ -219,7 +218,7 @@ class TestBaseUtilities(_GSSAPIKerberosTestCase):
 
         exported_name = gb.export_name_composite(canon_name)
 
-        exported_name.should_be_a(bytes)
+        self.assertIsInstance(exported_name, bytes)
 
         # TODO(directxman12): when you just import a token as composite,
         # appears as this name whose text is all garbled, since it contains
@@ -235,10 +234,10 @@ class TestBaseUtilities(_GSSAPIKerberosTestCase):
 
         imported_name = gb.import_name(exported_name, gb.NameType.export)
 
-        imported_name.should_be_a(gb.Name)
+        self.assertIsInstance(imported_name, gb.Name)
 
         get_res = gb.get_name_attribute(imported_name, b'urn:greet:greeting')
-        get_res.values.should_be([b'some val'])
+        self.assertEqual(get_res.values, [b'some val'])
 
     def test_compare_name(self):
         service_name1 = gb.import_name(TARGET_SERVICE_NAME)
@@ -246,10 +245,10 @@ class TestBaseUtilities(_GSSAPIKerberosTestCase):
         init_name = gb.import_name(self.ADMIN_PRINC,
                                    gb.NameType.kerberos_principal)
 
-        gb.compare_name(service_name1, service_name2).should_be_true()
-        gb.compare_name(service_name2, service_name1).should_be_true()
+        self.assertTrue(gb.compare_name(service_name1, service_name2))
+        self.assertTrue(gb.compare_name(service_name2, service_name1))
 
-        gb.compare_name(service_name1, init_name).should_be_false()
+        self.assertFalse(gb.compare_name(service_name1, init_name))
 
         gb.release_name(service_name1)
         gb.release_name(service_name2)
@@ -257,33 +256,33 @@ class TestBaseUtilities(_GSSAPIKerberosTestCase):
 
     def test_display_status(self):
         status_resp = gbmisc._display_status(0, False)
-        status_resp.shouldnt_be_none()
+        self.assertIsNotNone(status_resp)
 
         (status, ctx, cont) = status_resp
 
-        status.should_be_a(bytes)
-        status.shouldnt_be_empty()
+        self.assertIsInstance(status, bytes)
+        self.assertTrue(status)
 
-        ctx.should_be_an_integer()
+        self.assertIsInstance(ctx, int)
 
-        cont.should_be_a(bool)
-        cont.should_be_false()
+        self.assertIsInstance(cont, bool)
+        self.assertFalse(cont)
 
     def test_acquire_creds(self):
         name = gb.import_name(SERVICE_PRINCIPAL,
                               gb.NameType.kerberos_principal)
         cred_resp = gb.acquire_cred(name)
-        cred_resp.shouldnt_be_none()
+        self.assertIsNotNone(cred_resp)
 
         (creds, actual_mechs, ttl) = cred_resp
 
-        creds.shouldnt_be_none()
-        creds.should_be_a(gb.Creds)
+        self.assertIsNotNone(creds)
+        self.assertIsInstance(creds, gb.Creds)
 
-        actual_mechs.shouldnt_be_empty()
-        actual_mechs.should_include(gb.MechType.kerberos)
+        self.assertTrue(actual_mechs)
+        self.assertIn(gb.MechType.kerberos, actual_mechs)
 
-        ttl.should_be_an_integer()
+        self.assertIsInstance(ttl, int)
 
         gb.release_name(name)
         gb.release_cred(creds)
@@ -297,7 +296,7 @@ class TestBaseUtilities(_GSSAPIKerberosTestCase):
         inquire_orig = gb.inquire_cred(creds, name=True)
         inquire_imp = gb.inquire_cred(imported_creds, name=True)
 
-        gb.compare_name(inquire_orig.name, inquire_imp.name).should_be_true()
+        self.assertTrue(gb.compare_name(inquire_orig.name, inquire_imp.name))
 
     def test_context_time(self):
         target_name = gb.import_name(TARGET_SERVICE_NAME,
@@ -320,8 +319,8 @@ class TestBaseUtilities(_GSSAPIKerberosTestCase):
 
         ttl = gb.context_time(ctx)
 
-        ttl.should_be_an_integer()
-        ttl.should_be_greater_than(0)
+        self.assertIsInstance(ttl, int)
+        self.assertGreater(ttl, 0)
 
     def test_inquire_context(self):
         target_name = gb.import_name(TARGET_SERVICE_NAME,
@@ -343,31 +342,31 @@ class TestBaseUtilities(_GSSAPIKerberosTestCase):
         ctx = client_resp2[0]
 
         inq_resp = gb.inquire_context(ctx)
-        inq_resp.shouldnt_be_none()
+        self.assertIsNotNone(inq_resp)
 
         (src_name, target_name, ttl, mech_type,
          flags, local_est, is_open) = inq_resp
 
-        src_name.shouldnt_be_none()
-        src_name.should_be_a(gb.Name)
+        self.assertIsNotNone(src_name)
+        self.assertIsInstance(src_name, gb.Name)
 
-        target_name.shouldnt_be_none()
-        target_name.should_be_a(gb.Name)
+        self.assertIsNotNone(target_name)
+        self.assertIsInstance(target_name, gb.Name)
 
-        ttl.should_be_an_integer()
+        self.assertIsInstance(ttl, int)
 
-        mech_type.shouldnt_be_none()
-        mech_type.should_be(gb.MechType.kerberos)
+        self.assertIsNotNone(mech_type)
+        self.assertEqual(mech_type, gb.MechType.kerberos)
 
-        flags.shouldnt_be_none()
-        flags.should_be_a(Set)
-        flags.shouldnt_be_empty()
+        self.assertIsNotNone(flags)
+        self.assertIsInstance(flags, Set)
+        self.assertTrue(flags)
 
-        local_est.should_be_a(bool)
-        local_est.should_be_true()
+        self.assertIsInstance(local_est, bool)
+        self.assertTrue(local_est)
 
-        is_open.should_be_a(bool)
-        is_open.should_be_true()
+        self.assertIsInstance(is_open, bool)
+        self.assertTrue(is_open)
 
     # NB(directxman12): We don't test `process_context_token` because
     #                   there is no clear non-deprecated way to test it
@@ -392,17 +391,17 @@ class TestBaseUtilities(_GSSAPIKerberosTestCase):
                                                 server_ctx_resp[1],
                                                 gb.MechType.kerberos)
 
-        imp_resp.shouldnt_be_none()
+        self.assertIsNotNone(imp_resp)
 
         new_creds, actual_mechs, output_init_ttl, output_accept_ttl = imp_resp
 
-        actual_mechs.shouldnt_be_empty()
-        actual_mechs.should_include(gb.MechType.kerberos)
+        self.assertTrue(actual_mechs)
+        self.assertIn(gb.MechType.kerberos, actual_mechs)
 
-        output_init_ttl.should_be_a(int)
-        output_accept_ttl.should_be_a(int)
+        self.assertIsInstance(output_init_ttl, int)
+        self.assertIsInstance(output_accept_ttl, int)
 
-        new_creds.should_be_a(gb.Creds)
+        self.assertIsInstance(new_creds, gb.Creds)
 
     @ktu.gssapi_extension_test('s4u', 'S4U')
     def test_acquire_creds_impersonate_name(self):
@@ -421,17 +420,17 @@ class TestBaseUtilities(_GSSAPIKerberosTestCase):
         imp_resp = gb.acquire_cred_impersonate_name(server_creds,
                                                     server_ctx_resp[1])
 
-        imp_resp.shouldnt_be_none()
+        self.assertIsNotNone(imp_resp)
 
         imp_creds, actual_mechs, output_ttl = imp_resp
 
-        imp_creds.shouldnt_be_none()
-        imp_creds.should_be_a(gb.Creds)
+        self.assertIsNotNone(imp_creds)
+        self.assertIsInstance(imp_creds, gb.Creds)
 
-        actual_mechs.shouldnt_be_empty()
-        actual_mechs.should_include(gb.MechType.kerberos)
+        self.assertTrue(actual_mechs)
+        self.assertIn(gb.MechType.kerberos, actual_mechs)
 
-        output_ttl.should_be_a(int)
+        self.assertIsInstance(output_ttl, int)
         # no need to explicitly release any more -- we can just rely on
         # __dealloc__ (b/c cython)
 
@@ -453,9 +452,9 @@ class TestBaseUtilities(_GSSAPIKerberosTestCase):
         server_ctx_resp = gb.accept_sec_context(client_token,
                                                 acceptor_creds=server_creds)
 
-        server_ctx_resp.shouldnt_be_none()
-        server_ctx_resp.delegated_creds.shouldnt_be_none()
-        server_ctx_resp.delegated_creds.should_be_a(gb.Creds)
+        self.assertIsNotNone(server_ctx_resp)
+        self.assertIsNotNone(server_ctx_resp.delegated_creds)
+        self.assertIsInstance(server_ctx_resp.delegated_creds, gb.Creds)
 
     @ktu.gssapi_extension_test('rfc5588', 'RFC 5588')
     def test_store_cred_acquire_cred(self):
@@ -478,17 +477,17 @@ class TestBaseUtilities(_GSSAPIKerberosTestCase):
                                                 acceptor_creds=server_creds)
 
         deleg_creds = server_ctx_resp.delegated_creds
-        deleg_creds.shouldnt_be_none()
+        self.assertIsNotNone(deleg_creds)
         store_res = gb.store_cred(deleg_creds, usage='initiate',
                                   set_default=True, overwrite=True)
 
-        store_res.shouldnt_be_none()
-        store_res.usage.should_be('initiate')
-        store_res.mechs.should_include(gb.MechType.kerberos)
+        self.assertIsNotNone(store_res)
+        self.assertEqual(store_res.usage, 'initiate')
+        self.assertIn(gb.MechType.kerberos, store_res.mechs)
 
         deleg_name = gb.inquire_cred(deleg_creds).name
         acq_resp = gb.acquire_cred(deleg_name, usage='initiate')
-        acq_resp.shouldnt_be_none()
+        self.assertIsNotNone(acq_resp)
 
     @ktu.gssapi_extension_test('cred_store', 'credentials store')
     def test_store_cred_into_acquire_cred(self):
@@ -507,20 +506,20 @@ class TestBaseUtilities(_GSSAPIKerberosTestCase):
         # NB(sross): overwrite because the ccache doesn't exist yet
         store_res = gb.store_cred_into(store, initial_creds, overwrite=True)
 
-        store_res.mechs.shouldnt_be_none()
-        store_res.usage.should_be('initiate')
+        self.assertIsNotNone(store_res.mechs)
+        self.assertEqual(store_res.usage, 'initiate')
 
         name = gb.import_name(princ_name.encode('UTF-8'))
         retrieve_res = gb.acquire_cred_from(store, name)
 
-        retrieve_res.shouldnt_be_none()
-        retrieve_res.creds.shouldnt_be_none()
-        retrieve_res.creds.should_be_a(gb.Creds)
+        self.assertIsNotNone(retrieve_res)
+        self.assertIsNotNone(retrieve_res.creds)
+        self.assertIsInstance(retrieve_res.creds, gb.Creds)
 
-        retrieve_res.mechs.shouldnt_be_empty()
-        retrieve_res.mechs.should_include(gb.MechType.kerberos)
+        self.assertTrue(retrieve_res.mechs)
+        self.assertIn(gb.MechType.kerberos, retrieve_res.mechs)
 
-        retrieve_res.lifetime.should_be_an_integer()
+        self.assertIsInstance(retrieve_res.lifetime, int)
 
     def test_add_cred(self):
         target_name = gb.import_name(TARGET_SERVICE_NAME,
@@ -540,17 +539,17 @@ class TestBaseUtilities(_GSSAPIKerberosTestCase):
                                server_ctx_resp[1],
                                gb.MechType.kerberos)
 
-        imp_resp.shouldnt_be_none()
+        self.assertIsNotNone(imp_resp)
 
         new_creds, actual_mechs, output_init_ttl, output_accept_ttl = imp_resp
 
-        actual_mechs.shouldnt_be_empty()
-        actual_mechs.should_include(gb.MechType.kerberos)
+        self.assertTrue(actual_mechs)
+        self.assertIn(gb.MechType.kerberos, actual_mechs)
 
-        output_init_ttl.should_be_a(int)
-        output_accept_ttl.should_be_a(int)
+        self.assertIsInstance(output_init_ttl, int)
+        self.assertIsInstance(output_accept_ttl, int)
 
-        new_creds.should_be_a(gb.Creds)
+        self.assertIsInstance(new_creds, gb.Creds)
 
     # NB(sross): we skip testing add_cred with mutate for the same reasons
     #            that testing add_cred in the high-level API is skipped
@@ -562,23 +561,23 @@ class TestBaseUtilities(_GSSAPIKerberosTestCase):
 
         inq_resp = gb.inquire_cred(cred)
 
-        inq_resp.shouldnt_be_none()
+        self.assertIsNotNone(inq_resp)
 
-        inq_resp.name.should_be_a(gb.Name)
+        self.assertIsInstance(inq_resp.name, gb.Name)
         assert gb.compare_name(name, inq_resp.name)
 
-        inq_resp.lifetime.should_be_an_integer()
+        self.assertIsInstance(inq_resp.lifetime, int)
 
-        inq_resp.usage.should_be('both')
+        self.assertEqual(inq_resp.usage, 'both')
 
-        inq_resp.mechs.shouldnt_be_empty()
-        inq_resp.mechs.should_include(gb.MechType.kerberos)
+        self.assertTrue(inq_resp.mechs)
+        self.assertIn(gb.MechType.kerberos, inq_resp.mechs)
 
     def test_create_oid_from_bytes(self):
         kerberos_bytes = gb.MechType.kerberos.__bytes__()
         new_oid = gb.OID(elements=kerberos_bytes)
 
-        new_oid.should_be(gb.MechType.kerberos)
+        self.assertEqual(new_oid, gb.MechType.kerberos)
 
         del new_oid  # make sure we can dealloc
 
@@ -587,14 +586,14 @@ class TestBaseUtilities(_GSSAPIKerberosTestCase):
         err_code2 = gb.BadNameError.ROUTINE_CODE
         err = gb.GSSError(err_code1 | err_code2, 0)
 
-        err.should_be_a(gb.NameReadError)
-        err.maj_code.should_be(err_code1 | err_code2)
+        self.assertIsInstance(err, gb.NameReadError)
+        self.assertEqual(err.maj_code, err_code1 | err_code2)
 
     def test_inquire_names_for_mech(self):
         res = gb.inquire_names_for_mech(gb.MechType.kerberos)
 
-        res.shouldnt_be_none()
-        res.should_include(gb.NameType.kerberos_principal)
+        self.assertIsNotNone(res)
+        self.assertIn(gb.NameType.kerberos_principal, res)
 
     def test_inquire_mechs_for_name(self):
         name = gb.import_name(self.USER_PRINC,
@@ -602,8 +601,8 @@ class TestBaseUtilities(_GSSAPIKerberosTestCase):
 
         res = gb.inquire_mechs_for_name(name)
 
-        res.shouldnt_be_none()
-        res.should_include(gb.MechType.kerberos)
+        self.assertIsNotNone(res)
+        self.assertIn(gb.MechType.kerberos, res)
 
     @ktu.gssapi_extension_test('password', 'Password')
     def test_acquire_cred_with_password(self):
@@ -614,17 +613,17 @@ class TestBaseUtilities(_GSSAPIKerberosTestCase):
 
         imp_resp = gb.acquire_cred_with_password(name,
                                                  password.encode('UTF-8'))
-        imp_resp.shouldnt_be_none()
+        self.assertIsNotNone(imp_resp)
 
         imp_creds, actual_mechs, output_ttl = imp_resp
 
-        imp_creds.shouldnt_be_none()
-        imp_creds.should_be_a(gb.Creds)
+        self.assertIsNotNone(imp_creds)
+        self.assertIsInstance(imp_creds, gb.Creds)
 
-        actual_mechs.shouldnt_be_empty()
-        actual_mechs.should_include(gb.MechType.kerberos)
+        self.assertTrue(actual_mechs)
+        self.assertIn(gb.MechType.kerberos, actual_mechs)
 
-        output_ttl.should_be_a(int)
+        self.assertIsInstance(output_ttl, int)
 
     @ktu.gssapi_extension_test('password_add', 'Password (add)')
     def test_add_cred_with_password(self):
@@ -637,24 +636,24 @@ class TestBaseUtilities(_GSSAPIKerberosTestCase):
         imp_resp = gb.add_cred_with_password(input_creds, name,
                                              gb.MechType.kerberos,
                                              password.encode('UTF-8'))
-        imp_resp.shouldnt_be_none()
+        self.assertIsNotNone(imp_resp)
 
         new_creds, actual_mechs, output_init_ttl, output_accept_ttl = imp_resp
 
-        actual_mechs.shouldnt_be_empty()
-        actual_mechs.should_include(gb.MechType.kerberos)
+        self.assertTrue(actual_mechs)
+        self.assertIn(gb.MechType.kerberos, actual_mechs)
 
-        output_init_ttl.should_be_a(int)
-        output_accept_ttl.should_be_a(int)
+        self.assertIsInstance(output_init_ttl, int)
+        self.assertIsInstance(output_accept_ttl, int)
 
-        new_creds.should_be_a(gb.Creds)
+        self.assertIsInstance(new_creds, gb.Creds)
 
     @ktu.gssapi_extension_test('rfc5587', 'RFC 5587')
     def test_rfc5587(self):
         mechs = gb.indicate_mechs_by_attrs(None, None, None)
 
-        mechs.should_be_a(set)
-        mechs.shouldnt_be_empty()
+        self.assertIsInstance(mechs, set)
+        self.assertTrue(mechs)
 
         # We're validating RFC 5587 here: by iterating over all mechanisms,
         # we can query their attributes and build a mapping of attr->{mechs}.
@@ -665,47 +664,47 @@ class TestBaseUtilities(_GSSAPIKerberosTestCase):
         known_attrs_dict = {}
 
         for mech in mechs:
-            mech.shouldnt_be_none()
-            mech.should_be_a(gb.OID)
+            self.assertIsNotNone(mech)
+            self.assertIsInstance(mech, gb.OID)
 
             inquire_out = gb.inquire_attrs_for_mech(mech)
             mech_attrs = inquire_out.mech_attrs
             known_mech_attrs = inquire_out.known_mech_attrs
 
-            mech_attrs.should_be_a(set)
+            self.assertIsInstance(mech_attrs, set)
 
-            known_mech_attrs.should_be_a(set)
+            self.assertIsInstance(known_mech_attrs, set)
 
             # Verify that we get data for every available
             # attribute. Testing the contents of a few known
             # attributes is done in test_display_mech_attr().
             for mech_attr in mech_attrs:
-                mech_attr.shouldnt_be_none()
-                mech_attr.should_be_a(gb.OID)
+                self.assertIsNotNone(mech_attr)
+                self.assertIsInstance(mech_attr, gb.OID)
 
                 display_out = gb.display_mech_attr(mech_attr)
-                display_out.name.shouldnt_be_none()
-                display_out.short_desc.shouldnt_be_none()
-                display_out.long_desc.shouldnt_be_none()
-                display_out.name.should_be_a(bytes)
-                display_out.short_desc.should_be_a(bytes)
-                display_out.long_desc.should_be_a(bytes)
+                self.assertIsNotNone(display_out.name)
+                self.assertIsNotNone(display_out.short_desc)
+                self.assertIsNotNone(display_out.long_desc)
+                self.assertIsInstance(display_out.name, bytes)
+                self.assertIsInstance(display_out.short_desc, bytes)
+                self.assertIsInstance(display_out.long_desc, bytes)
 
                 if mech_attr not in attrs_dict:
                     attrs_dict[mech_attr] = set()
                 attrs_dict[mech_attr].add(mech)
 
             for mech_attr in known_mech_attrs:
-                mech_attr.shouldnt_be_none()
-                mech_attr.should_be_a(gb.OID)
+                self.assertIsNotNone(mech_attr)
+                self.assertIsInstance(mech_attr, gb.OID)
 
                 display_out = gb.display_mech_attr(mech_attr)
-                display_out.name.shouldnt_be_none()
-                display_out.short_desc.shouldnt_be_none()
-                display_out.long_desc.shouldnt_be_none()
-                display_out.name.should_be_a(bytes)
-                display_out.short_desc.should_be_a(bytes)
-                display_out.long_desc.should_be_a(bytes)
+                self.assertIsNotNone(display_out.name)
+                self.assertIsNotNone(display_out.short_desc)
+                self.assertIsNotNone(display_out.long_desc)
+                self.assertIsInstance(display_out.name, bytes)
+                self.assertIsInstance(display_out.short_desc, bytes)
+                self.assertIsInstance(display_out.long_desc, bytes)
 
                 if mech_attr not in known_attrs_dict:
                     known_attrs_dict[mech_attr] = set()
@@ -715,19 +714,19 @@ class TestBaseUtilities(_GSSAPIKerberosTestCase):
             attrs = set([attr])
 
             mechs = gb.indicate_mechs_by_attrs(attrs, None, None)
-            mechs.shouldnt_be_empty()
-            mechs.should_be(expected_mechs)
+            self.assertTrue(mechs)
+            self.assertEqual(mechs, expected_mechs)
 
             mechs = gb.indicate_mechs_by_attrs(None, attrs, None)
             for expected_mech in expected_mechs:
-                mechs.shouldnt_include(expected_mech)
+                self.assertNotIn(expected_mech, mechs)
 
         for attr, expected_mechs in known_attrs_dict.items():
             attrs = set([attr])
 
             mechs = gb.indicate_mechs_by_attrs(None, None, attrs)
-            mechs.shouldnt_be_empty()
-            mechs.should_be(expected_mechs)
+            self.assertTrue(mechs)
+            self.assertEqual(mechs, expected_mechs)
 
     @ktu.gssapi_extension_test('rfc5587', 'RFC 5587')
     def test_display_mech_attr(self):
@@ -744,9 +743,9 @@ class TestBaseUtilities(_GSSAPIKerberosTestCase):
 
         for attr in test_attrs:
             display_out = gb.display_mech_attr(attr[0])
-            display_out.name.should_be(attr[1])
-            display_out.short_desc.should_be(attr[2])
-            display_out.long_desc.should_be(attr[3])
+            self.assertEqual(attr[1], display_out.name)
+            self.assertEqual(attr[2], display_out.short_desc)
+            self.assertEqual(attr[3], display_out.long_desc)
 
     @ktu.gssapi_extension_test('rfc5801', 'SASL Names')
     def test_sasl_names(self):
@@ -756,21 +755,21 @@ class TestBaseUtilities(_GSSAPIKerberosTestCase):
             out = gb.inquire_saslname_for_mech(mech)
 
             out_smn = out.sasl_mech_name
-            out_smn.shouldnt_be_none()
-            out_smn.should_be_a(bytes)
-            out_smn.shouldnt_be_empty()
+            self.assertIsNotNone(out_smn)
+            self.assertIsInstance(out_smn, bytes)
+            self.assertTrue(out_smn)
 
             out_mn = out.mech_name
-            out_mn.shouldnt_be_none()
-            out_mn.should_be_a(bytes)
+            self.assertIsNotNone(out_mn)
+            self.assertIsInstance(out_mn, bytes)
 
             out_md = out.mech_description
-            out_md.shouldnt_be_none()
-            out_md.should_be_a(bytes)
+            self.assertIsNotNone(out_md)
+            self.assertIsInstance(out_md, bytes)
 
             cmp_mech = gb.inquire_mech_for_saslname(out_smn)
-            cmp_mech.shouldnt_be_none()
-            cmp_mech.should_be(mech)
+            self.assertIsNotNone(cmp_mech)
+            self.assertEqual(cmp_mech, mech)
 
     @ktu.gssapi_extension_test('rfc4178', 'Negotiation Mechanism')
     def test_set_neg_mechs(self):
@@ -800,7 +799,7 @@ class TestBaseUtilities(_GSSAPIKerberosTestCase):
                                        mechs=all_mechs).creds
 
         neg_resp = gb.set_neg_mechs(server_creds, [ntlm_mech])
-        neg_resp.should_be_none()
+        self.assertIsNone(neg_resp)
 
         client_ctx_resp = gb.init_sec_context(server_name,
                                               creds=ntlm_client_creds,
@@ -809,18 +808,18 @@ class TestBaseUtilities(_GSSAPIKerberosTestCase):
 
         server_ctx_resp = gb.accept_sec_context(client_token,
                                                 acceptor_creds=server_creds)
-        server_ctx_resp.shouldnt_be_none()
+        self.assertIsNotNone(server_ctx_resp)
 
         client_ctx_resp = gb.init_sec_context(server_name,
                                               creds=krb5_client_creds,
                                               mech=spnego_mech)
         client_token = client_ctx_resp.token
 
-        gb.accept_sec_context.should_raise(gb.GSSError, client_token,
-                                           acceptor_creds=server_creds)
+        self.assertRaises(gb.GSSError, gb.accept_sec_context, client_token,
+                          acceptor_creds=server_creds)
 
         neg_resp = gb.set_neg_mechs(server_creds, [krb5_mech])
-        neg_resp.should_be_none()
+        self.assertIsNone(neg_resp)
 
         client_ctx_resp = gb.init_sec_context(server_name,
                                               creds=krb5_client_creds,
@@ -829,15 +828,15 @@ class TestBaseUtilities(_GSSAPIKerberosTestCase):
 
         server_ctx_resp = gb.accept_sec_context(client_token,
                                                 acceptor_creds=server_creds)
-        server_ctx_resp.shouldnt_be_none()
+        self.assertIsNotNone(server_ctx_resp)
 
         client_ctx_resp = gb.init_sec_context(server_name,
                                               creds=ntlm_client_creds,
                                               mech=spnego_mech)
         client_token = client_ctx_resp.token
 
-        gb.accept_sec_context.should_raise(gb.GSSError, client_token,
-                                           acceptor_creds=server_creds)
+        self.assertRaises(gb.GSSError, gb.accept_sec_context, client_token,
+                          acceptor_creds=server_creds)
 
     @ktu.gssapi_extension_test('ggf', 'Global Grid Forum')
     @ktu.gssapi_extension_test('s4u', 'S4U')
@@ -860,19 +859,19 @@ class TestBaseUtilities(_GSSAPIKerberosTestCase):
         server_ctx_resp = gb.accept_sec_context(client_token,
                                                 acceptor_creds=server_creds)
 
-        server_ctx_resp.shouldnt_be_none()
-        server_ctx_resp.delegated_creds.shouldnt_be_none()
-        server_ctx_resp.delegated_creds.should_be_a(gb.Creds)
+        self.assertIsNotNone(server_ctx_resp)
+        self.assertIsNotNone(server_ctx_resp.delegated_creds)
+        self.assertIsInstance(server_ctx_resp.delegated_creds, gb.Creds)
 
         # GSS_KRB5_GET_CRED_IMPERSONATOR
         oid = gb.OID.from_int_seq("1.2.840.113554.1.2.2.5.14")
         info = gb.inquire_cred_by_oid(server_ctx_resp.delegated_creds, oid)
 
-        info.should_be_a(list)
-        info.shouldnt_be_empty()
-        info[0].should_be_a(bytes)
-        info[0].should_be(b"%s@%s" % (SERVICE_PRINCIPAL,
-                                      self.realm.realm.encode('utf-8')))
+        self.assertIsInstance(info, list)
+        self.assertTrue(info)
+        self.assertIsInstance(info[0], bytes)
+        self.assertEqual(info[0], b"%s@%s" % (SERVICE_PRINCIPAL,
+                         self.realm.realm.encode('utf-8')))
 
     @ktu.gssapi_extension_test('ggf', 'Global Grid Forum')
     def test_inquire_sec_context_by_oid(self):
@@ -899,11 +898,11 @@ class TestBaseUtilities(_GSSAPIKerberosTestCase):
         client_key = gb.inquire_sec_context_by_oid(client_ctx, session_key_oid)
         server_key = gb.inquire_sec_context_by_oid(server_ctx, session_key_oid)
 
-        client_key.should_be_a(list)
-        client_key.shouldnt_be_empty()
-        server_key.should_be_a(list)
-        server_key.shouldnt_be_empty()
-        client_key.should_have_same_items_as(server_key)
+        self.assertIsInstance(client_key, list)
+        self.assertTrue(client_key)
+        self.assertIsInstance(server_key, list)
+        self.assertTrue(server_key)
+        six.assertCountEqual(self, client_key, server_key)
 
     @ktu.gssapi_extension_test('ggf', 'Global Grid Forum')
     def test_inquire_sec_context_by_oid_should_raise_error(self):
@@ -923,8 +922,8 @@ class TestBaseUtilities(_GSSAPIKerberosTestCase):
         client_ctx = client_resp2[0]
 
         invalid_oid = gb.OID.from_int_seq("1.2.3.4.5.6.7.8.9")
-        gb.inquire_sec_context_by_oid.should_raise(gb.GSSError, client_ctx,
-                                                   invalid_oid)
+        self.assertRaises(gb.GSSError, gb.inquire_sec_context_by_oid,
+                          client_ctx, invalid_oid)
 
     @ktu.gssapi_extension_test('ggf', 'Global Grid Forum')
     @ktu.gssapi_extension_test('password', 'Add Credential with Password')
@@ -950,7 +949,7 @@ class TestBaseUtilities(_GSSAPIKerberosTestCase):
         out_context = gb.set_sec_context_option(reset_mech,
                                                 context=orig_context,
                                                 value=b"\x00" * 4)
-        out_context.should_be_a(gb.SecurityContext)
+        self.assertIsInstance(out_context, gb.SecurityContext)
 
     @ktu.gssapi_extension_test('ggf', 'Global Grid Forum')
     @ktu.gssapi_extension_test('password', 'Add Credential with Password')
@@ -975,8 +974,8 @@ class TestBaseUtilities(_GSSAPIKerberosTestCase):
         reset_mech = gb.OID.from_int_seq("1.3.6.1.4.1.7165.655.1.3")
 
         # will raise a GSSError if no data was passed in
-        gb.set_sec_context_option.should_raise(gb.GSSError, reset_mech,
-                                               context)
+        self.assertRaises(gb.GSSError, gb.set_sec_context_option, reset_mech,
+                          context)
 
     @ktu.gssapi_extension_test('set_cred_opt', 'Kitten Set Credential Option')
     @ktu.krb_minversion_test('1.14',
@@ -992,7 +991,7 @@ class TestBaseUtilities(_GSSAPIKerberosTestCase):
         # nothing much we can test here apart from it doesn't fail and the
         # id of the return cred is the same as the input one
         output_cred = gb.set_cred_option(no_ci_flags_x, creds=orig_cred)
-        output_cred.should_be_a(gb.Creds)
+        self.assertIsInstance(output_cred, gb.Creds)
 
     @ktu.gssapi_extension_test('set_cred_opt', 'Kitten Set Credential Option')
     def test_set_cred_option_should_raise_error(self):
@@ -1002,8 +1001,8 @@ class TestBaseUtilities(_GSSAPIKerberosTestCase):
 
         # this is a fake OID and shouldn't work at all
         invalid_oid = gb.OID.from_int_seq("1.2.3.4.5.6.7.8.9")
-        gb.set_cred_option.should_raise(gb.GSSError, invalid_oid, orig_cred,
-                                        b"\x00")
+        self.assertRaises(gb.GSSError, gb.set_cred_option, invalid_oid,
+                          orig_cred, b"\x00")
 
 
 class TestIntEnumFlagSet(unittest.TestCase):
@@ -1012,7 +1011,7 @@ class TestIntEnumFlagSet(unittest.TestCase):
                    gb.RequirementFlag.confidentiality)
         fset = gb.IntEnumFlagSet(gb.RequirementFlag, int_val)
 
-        int(fset).should_be(int_val)
+        self.assertEqual(int(fset), int_val)
 
     def test_create_from_other_set(self):
         int_val = (gb.RequirementFlag.integrity |
@@ -1020,18 +1019,21 @@ class TestIntEnumFlagSet(unittest.TestCase):
         fset1 = gb.IntEnumFlagSet(gb.RequirementFlag, int_val)
         fset2 = gb.IntEnumFlagSet(gb.RequirementFlag, fset1)
 
-        fset1.should_be(fset2)
+        self.assertEqual(fset1, fset2)
 
     def test_create_from_list(self):
         lst = [gb.RequirementFlag.integrity,
                gb.RequirementFlag.confidentiality]
         fset = gb.IntEnumFlagSet(gb.RequirementFlag, lst)
 
-        list(fset).should_have_same_items_as(lst)
+        # in Python3 assertItemsEqual method is called assertCountEqual
+        # Six contains compatibility shims for unittest assertions that
+        # have been renamed
+        six.assertCountEqual(self, list(fset), lst)
 
     def test_create_empty(self):
         fset = gb.IntEnumFlagSet(gb.RequirementFlag)
-        fset.should_be_empty()
+        self.assertFalse(fset)
 
     def _create_fset(self):
         lst = [gb.RequirementFlag.integrity,
@@ -1040,41 +1042,41 @@ class TestIntEnumFlagSet(unittest.TestCase):
 
     def test_contains(self):
         fset = self._create_fset()
-        fset.should_include(gb.RequirementFlag.integrity)
-        fset.shouldnt_include(gb.RequirementFlag.protection_ready)
+        self.assertIn(gb.RequirementFlag.integrity, fset)
+        self.assertNotIn(gb.RequirementFlag.protection_ready, fset)
 
     def test_len(self):
-        self._create_fset().should_have_length(2)
+        self.assertEqual(len(self._create_fset()), 2)
 
     def test_add(self):
         fset = self._create_fset()
-        fset.should_have_length(2)
+        self.assertEqual(len(fset), 2)
 
         fset.add(gb.RequirementFlag.protection_ready)
-        fset.should_have_length(3)
-        fset.should_include(gb.RequirementFlag.protection_ready)
+        self.assertEqual(len(fset), 3)
+        self.assertIn(gb.RequirementFlag.protection_ready, fset)
 
     def test_discard(self):
         fset = self._create_fset()
-        fset.should_have_length(2)
+        self.assertEqual(len(fset), 2)
 
         fset.discard(gb.RequirementFlag.protection_ready)
-        fset.should_have_length(2)
+        self.assertEqual(len(fset), 2)
 
         fset.discard(gb.RequirementFlag.integrity)
-        fset.should_have_length(1)
-        fset.shouldnt_include(gb.RequirementFlag.integrity)
+        self.assertEqual(len(fset), 1)
+        self.assertNotIn(gb.RequirementFlag.integrity, fset)
 
     def test_and_enum(self):
         fset = self._create_fset()
-        (fset & gb.RequirementFlag.integrity).should_be_true()
-        (fset & gb.RequirementFlag.protection_ready).should_be_false()
+        self.assertTrue(fset & gb.RequirementFlag.integrity)
+        self.assertFalse(fset & gb.RequirementFlag.protection_ready)
 
     def test_and_int(self):
         fset = self._create_fset()
         int_val = int(gb.RequirementFlag.integrity)
 
-        (fset & int_val).should_be(int_val)
+        self.assertEqual(fset & int_val, int_val)
 
     def test_and_set(self):
         fset1 = self._create_fset()
@@ -1084,20 +1086,20 @@ class TestIntEnumFlagSet(unittest.TestCase):
         fset1.add(gb.RequirementFlag.protection_ready)
         fset2.add(gb.RequirementFlag.out_of_sequence_detection)
 
-        (fset1 & fset2).should_be(fset3)
+        self.assertEqual(fset1 & fset2, fset3)
 
     def test_or_enum(self):
         fset1 = self._create_fset()
         fset2 = fset1 | gb.RequirementFlag.protection_ready
 
-        (fset1 < fset2).should_be_true()
-        fset2.should_include(gb.RequirementFlag.protection_ready)
+        self.assertLess(fset1, fset2)
+        self.assertIn(gb.RequirementFlag.protection_ready, fset2)
 
     def test_or_int(self):
         fset = self._create_fset()
         int_val = int(gb.RequirementFlag.integrity)
 
-        (fset | int_val).should_be(int(fset))
+        self.assertEqual(fset | int_val, int(fset))
 
     def test_or_set(self):
         fset1 = self._create_fset()
@@ -1109,7 +1111,7 @@ class TestIntEnumFlagSet(unittest.TestCase):
         fset3.add(gb.RequirementFlag.protection_ready)
         fset3.add(gb.RequirementFlag.out_of_sequence_detection)
 
-        (fset1 | fset2).should_be(fset3)
+        self.assertEqual((fset1 | fset2), fset3)
 
     def test_xor_enum(self):
         fset1 = self._create_fset()
@@ -1117,20 +1119,20 @@ class TestIntEnumFlagSet(unittest.TestCase):
         fset2 = fset1 ^ gb.RequirementFlag.protection_ready
         fset3 = fset1 ^ gb.RequirementFlag.integrity
 
-        fset2.should_have_length(3)
-        fset2.should_include(gb.RequirementFlag.protection_ready)
+        self.assertEqual(len(fset2), 3)
+        self.assertIn(gb.RequirementFlag.protection_ready, fset2)
 
-        fset3.should_have_length(1)
-        fset3.shouldnt_include(gb.RequirementFlag.integrity)
+        self.assertEqual(len(fset3), 1)
+        self.assertNotIn(gb.RequirementFlag.integrity, fset3)
 
     def test_xor_int(self):
         fset = self._create_fset()
 
-        (fset ^ int(gb.RequirementFlag.protection_ready)).should_be(
-            int(fset) ^ gb.RequirementFlag.protection_ready)
+        self.assertEqual(fset ^ int(gb.RequirementFlag.protection_ready),
+                         int(fset) ^ gb.RequirementFlag.protection_ready)
 
-        (fset ^ int(gb.RequirementFlag.integrity)).should_be(
-            int(fset) ^ gb.RequirementFlag.integrity)
+        self.assertEqual(fset ^ int(gb.RequirementFlag.integrity),
+                         int(fset) ^ gb.RequirementFlag.integrity)
 
     def test_xor_set(self):
         fset1 = self._create_fset()
@@ -1140,11 +1142,11 @@ class TestIntEnumFlagSet(unittest.TestCase):
         fset2.add(gb.RequirementFlag.out_of_sequence_detection)
 
         fset3 = fset1 ^ fset2
-        fset3.should_have_length(2)
-        fset3.shouldnt_include(gb.RequirementFlag.integrity)
-        fset3.shouldnt_include(gb.RequirementFlag.confidentiality)
-        fset3.should_include(gb.RequirementFlag.protection_ready)
-        fset3.should_include(gb.RequirementFlag.out_of_sequence_detection)
+        self.assertEqual(len(fset3), 2)
+        self.assertNotIn(gb.RequirementFlag.integrity, fset3)
+        self.assertNotIn(gb.RequirementFlag.confidentiality, fset3)
+        self.assertIn(gb.RequirementFlag.protection_ready, fset3)
+        self.assertIn(gb.RequirementFlag.out_of_sequence_detection, fset3)
 
 
 class TestInitContext(_GSSAPIKerberosTestCase):
@@ -1157,24 +1159,24 @@ class TestInitContext(_GSSAPIKerberosTestCase):
 
     def test_basic_init_default_ctx(self):
         ctx_resp = gb.init_sec_context(self.target_name)
-        ctx_resp.shouldnt_be_none()
+        self.assertIsNotNone(ctx_resp)
 
         (ctx, out_mech_type,
          out_req_flags, out_token, out_ttl, cont_needed) = ctx_resp
 
-        ctx.shouldnt_be_none()
-        ctx.should_be_a(gb.SecurityContext)
+        self.assertIsNotNone(ctx)
+        self.assertIsInstance(ctx, gb.SecurityContext)
 
-        out_mech_type.should_be(gb.MechType.kerberos)
+        self.assertEqual(out_mech_type, gb.MechType.kerberos)
 
-        out_req_flags.should_be_a(Set)
-        out_req_flags.should_be_at_least_length(2)
+        self.assertIsInstance(out_req_flags, Set)
+        self.assertGreaterEqual(len(out_req_flags), 2)
 
-        out_token.shouldnt_be_empty()
+        self.assertTrue(out_token)
 
-        out_ttl.should_be_greater_than(0)
+        self.assertGreater(out_ttl, 0)
 
-        cont_needed.should_be_a(bool)
+        self.assertIsInstance(cont_needed, bool)
 
         gb.delete_sec_context(ctx)
 
@@ -1188,7 +1190,7 @@ class TestAcceptContext(_GSSAPIKerberosTestCase):
 
         self.client_token = ctx_resp[3]
         self.client_ctx = ctx_resp[0]
-        self.client_ctx.shouldnt_be_none()
+        self.assertIsNotNone(self.client_ctx)
 
         self.server_name = gb.import_name(SERVICE_PRINCIPAL,
                                           gb.NameType.kerberos_principal)
@@ -1207,58 +1209,58 @@ class TestAcceptContext(_GSSAPIKerberosTestCase):
 
     def test_basic_accept_context_no_acceptor_creds(self):
         server_resp = gb.accept_sec_context(self.client_token)
-        server_resp.shouldnt_be_none()
+        self.assertIsNotNone(server_resp)
 
         (self.server_ctx, name, mech_type, out_token,
          out_req_flags, out_ttl, delegated_cred, cont_needed) = server_resp
 
-        self.server_ctx.shouldnt_be_none()
-        self.server_ctx.should_be_a(gb.SecurityContext)
+        self.assertIsNotNone(self.server_ctx)
+        self.assertIsInstance(self.server_ctx, gb.SecurityContext)
 
-        name.shouldnt_be_none()
-        name.should_be_a(gb.Name)
+        self.assertIsNotNone(name)
+        self.assertIsInstance(name, gb.Name)
 
-        mech_type.should_be(gb.MechType.kerberos)
+        self.assertEqual(mech_type, gb.MechType.kerberos)
 
-        out_token.shouldnt_be_empty()
+        self.assertTrue(out_token)
 
-        out_req_flags.should_be_a(Set)
-        out_req_flags.should_be_at_least_length(2)
+        self.assertIsInstance(out_req_flags, Set)
+        self.assertGreaterEqual(len(out_req_flags), 2)
 
-        out_ttl.should_be_greater_than(0)
+        self.assertGreater(out_ttl, 0)
 
         if delegated_cred is not None:
-            delegated_cred.should_be_a(gb.Creds)
+            self.assertIsInstance(delegated_cred, gb.Creds)
 
-        cont_needed.should_be_a(bool)
+        self.assertIsInstance(cont_needed, bool)
 
     def test_basic_accept_context(self):
         server_resp = gb.accept_sec_context(self.client_token,
                                             acceptor_creds=self.server_creds)
-        server_resp.shouldnt_be_none()
+        self.assertIsNotNone(server_resp)
 
         (self.server_ctx, name, mech_type, out_token,
          out_req_flags, out_ttl, delegated_cred, cont_needed) = server_resp
 
-        self.server_ctx.shouldnt_be_none()
-        self.server_ctx.should_be_a(gb.SecurityContext)
+        self.assertIsNotNone(self.server_ctx)
+        self.assertIsInstance(self.server_ctx, gb.SecurityContext)
 
-        name.shouldnt_be_none()
-        name.should_be_a(gb.Name)
+        self.assertIsNotNone(name)
+        self.assertIsInstance(name, gb.Name)
 
-        mech_type.should_be(gb.MechType.kerberos)
+        self.assertEqual(mech_type, gb.MechType.kerberos)
 
-        out_token.shouldnt_be_empty()
+        self.assertTrue(out_token)
 
-        out_req_flags.should_be_a(Set)
-        out_req_flags.should_be_at_least_length(2)
+        self.assertIsInstance(out_req_flags, Set)
+        self.assertGreaterEqual(len(out_req_flags), 2)
 
-        out_ttl.should_be_greater_than(0)
+        self.assertGreater(out_ttl, 0)
 
         if delegated_cred is not None:
-            delegated_cred.should_be_a(gb.Creds)
+            self.assertIsInstance(delegated_cred, gb.Creds)
 
-        cont_needed.should_be_a(bool)
+        self.assertIsInstance(cont_needed, bool)
 
     def test_channel_bindings(self):
         bdgs = gb.ChannelBindings(application_data=b'abcxyz',
@@ -1273,7 +1275,7 @@ class TestAcceptContext(_GSSAPIKerberosTestCase):
 
         self.client_token = ctx_resp[3]
         self.client_ctx = ctx_resp[0]
-        self.client_ctx.shouldnt_be_none()
+        self.assertIsNotNone(self.client_ctx)
 
         self.server_name = gb.import_name(SERVICE_PRINCIPAL,
                                           gb.NameType.kerberos_principal)
@@ -1282,7 +1284,7 @@ class TestAcceptContext(_GSSAPIKerberosTestCase):
         server_resp = gb.accept_sec_context(self.client_token,
                                             acceptor_creds=self.server_creds,
                                             channel_bindings=bdgs)
-        server_resp.shouldnt_be_none
+        self.assertIsNotNone(server_resp)
         self.server_ctx = server_resp.context
 
     def test_bad_channel_binding_raises_error(self):
@@ -1298,16 +1300,16 @@ class TestAcceptContext(_GSSAPIKerberosTestCase):
 
         self.client_token = ctx_resp[3]
         self.client_ctx = ctx_resp[0]
-        self.client_ctx.shouldnt_be_none()
+        self.assertIsNotNone(self.client_ctx)
 
         self.server_name = gb.import_name(SERVICE_PRINCIPAL,
                                           gb.NameType.kerberos_principal)
         self.server_creds = gb.acquire_cred(self.server_name)[0]
 
         bdgs.acceptor_address = b'127.0.1.0'
-        gb.accept_sec_context.should_raise(gb.GSSError, self.client_token,
-                                           acceptor_creds=self.server_creds,
-                                           channel_bindings=bdgs)
+        self.assertRaises(gb.GSSError, gb.accept_sec_context,
+                          self.client_token, acceptor_creds=self.server_creds,
+                          channel_bindings=bdgs)
 
 
 class TestWrapUnwrap(_GSSAPIKerberosTestCase):
@@ -1342,66 +1344,66 @@ class TestWrapUnwrap(_GSSAPIKerberosTestCase):
     def test_import_export_sec_context(self):
         tok = gb.export_sec_context(self.client_ctx)
 
-        tok.shouldnt_be_none()
-        tok.should_be_a(bytes)
-        tok.shouldnt_be_empty()
+        self.assertIsNotNone(tok)
+        self.assertIsInstance(tok, bytes)
+        self.assertTrue(tok)
 
         imported_ctx = gb.import_sec_context(tok)
-        imported_ctx.shouldnt_be_none()
-        imported_ctx.should_be_a(gb.SecurityContext)
+        self.assertIsNotNone(imported_ctx)
+        self.assertIsInstance(imported_ctx, gb.SecurityContext)
 
         self.client_ctx = imported_ctx  # ensure that it gets deleted
 
     def test_get_mic(self):
         mic_token = gb.get_mic(self.client_ctx, b"some message")
 
-        mic_token.shouldnt_be_none()
-        mic_token.should_be_a(bytes)
-        mic_token.shouldnt_be_empty()
+        self.assertIsNotNone(mic_token)
+        self.assertIsInstance(mic_token, bytes)
+        self.assertTrue(mic_token)
 
     def test_basic_verify_mic(self):
         mic_token = gb.get_mic(self.client_ctx, b"some message")
 
         qop_used = gb.verify_mic(self.server_ctx, b"some message", mic_token)
 
-        qop_used.should_be_an_integer()
+        self.assertIsInstance(qop_used, int)
 
         # test a bad MIC
-        gb.verify_mic.should_raise(gb.GSSError, self.server_ctx,
-                                   b"some other message", b"some invalid mic")
+        self.assertRaises(gb.GSSError, gb.verify_mic, self.server_ctx,
+                          b"some other message", b"some invalid mic")
 
     def test_wrap_size_limit(self):
         with_conf = gb.wrap_size_limit(self.client_ctx, 100)
         without_conf = gb.wrap_size_limit(self.client_ctx, 100,
                                           confidential=False)
 
-        with_conf.should_be_an_integer()
-        without_conf.should_be_an_integer()
+        self.assertIsInstance(with_conf, int)
+        self.assertIsInstance(without_conf, int)
 
-        without_conf.should_be_less_than(100)
-        with_conf.should_be_less_than(100)
+        self.assertLess(without_conf, 100)
+        self.assertLess(with_conf, 100)
 
     def test_basic_wrap_unwrap(self):
         (wrapped_message, conf) = gb.wrap(self.client_ctx, b'test message')
 
-        conf.should_be_a(bool)
-        conf.should_be_true()
+        self.assertIsInstance(conf, bool)
+        self.assertTrue(conf)
 
-        wrapped_message.should_be_a(bytes)
-        wrapped_message.shouldnt_be_empty()
-        wrapped_message.should_be_longer_than('test message')
+        self.assertIsInstance(wrapped_message, bytes)
+        self.assertTrue(wrapped_message)
+        self.assertGreater(len(wrapped_message), len('test message'))
 
         (unwrapped_message, conf, qop) = gb.unwrap(self.server_ctx,
                                                    wrapped_message)
-        conf.should_be_a(bool)
-        conf.should_be_true()
+        self.assertIsInstance(conf, bool)
+        self.assertTrue(conf)
 
-        qop.should_be_an_integer()
-        qop.should_be_at_least(0)
+        self.assertIsInstance(qop, int)
+        self.assertLessEqual(qop, 0)
 
-        unwrapped_message.should_be_a(bytes)
-        unwrapped_message.shouldnt_be_empty()
-        unwrapped_message.should_be(b'test message')
+        self.assertIsInstance(unwrapped_message, bytes)
+        self.assertTrue(unwrapped_message)
+        self.assertEqual(unwrapped_message, b'test message')
 
     @ktu.gssapi_extension_test('dce', 'DCE (IOV/AEAD)')
     def test_basic_iov_wrap_unwrap_prealloc(self):
@@ -1411,41 +1413,42 @@ class TestWrapUnwrap(_GSSAPIKerberosTestCase):
         init_message = gb.IOV((gb.IOVBufferType.sign_only, init_signed_info),
                               init_data, init_other_data, auto_alloc=False)
 
-        init_message[0].allocate.should_be_false()
-        init_message[4].allocate.should_be_false()
-        init_message[5].allocate.should_be_false()
+        self.assertFalse(init_message[0].allocate)
+        self.assertFalse(init_message[4].allocate)
+        self.assertFalse(init_message[5].allocate)
 
         conf = gb.wrap_iov_length(self.client_ctx, init_message)
 
-        conf.should_be_a(bool)
-        conf.should_be_true()
+        self.assertIsInstance(conf, bool)
+        self.assertTrue(conf)
 
-        init_message[0].should_be_at_least_size(1)
-        init_message[5].should_be_at_least_size(1)
+        self.assertGreaterEqual(len(init_message[0]), 1)
+        self.assertGreaterEqual(len(init_message[5]), 1)
 
         conf = gb.wrap_iov(self.client_ctx, init_message)
 
-        conf.should_be_a(bool)
-        conf.should_be_true()
+        self.assertIsInstance(conf, bool)
+        self.assertTrue(conf)
 
         # make sure we didn't strings used
-        init_data.should_be(b'some encrypted data')
-        init_other_data.should_be(b'some other encrypted data')
-        init_signed_info.should_be(b'some sig data')
+        self.assertEqual(init_data, b'some encrypted data')
+        self.assertEqual(init_other_data, b'some other encrypted data')
+        self.assertEqual(init_signed_info, b'some sig data')
 
-        init_message[2].value.shouldnt_be(b'some encrypted data')
-        init_message[3].value.shouldnt_be(b'some other encrypted data')
+        self.assertNotEqual(init_message[2].value, b'some encrypted data')
+        self.assertNotEqual(init_message[3].value,
+                            b'some other encrypted data')
 
         (conf, qop) = gb.unwrap_iov(self.server_ctx, init_message)
 
-        conf.should_be_a(bool)
-        conf.should_be_true()
+        self.assertIsInstance(conf, bool)
+        self.assertTrue(conf)
 
-        qop.should_be_a(int)
+        self.assertIsInstance(qop, int)
 
-        init_message[1].value.should_be(init_signed_info)
-        init_message[2].value.should_be(init_data)
-        init_message[3].value.should_be(init_other_data)
+        self.assertEqual(init_message[1].value, init_signed_info)
+        self.assertEqual(init_message[2].value, init_data)
+        self.assertEqual(init_message[3].value, init_other_data)
 
     @ktu.gssapi_extension_test('dce', 'DCE (IOV/AEAD)')
     def test_basic_iov_wrap_unwrap_autoalloc(self):
@@ -1457,27 +1460,28 @@ class TestWrapUnwrap(_GSSAPIKerberosTestCase):
 
         conf = gb.wrap_iov(self.client_ctx, init_message)
 
-        conf.should_be_a(bool)
-        conf.should_be_true()
+        self.assertIsInstance(conf, bool)
+        self.assertTrue(conf)
 
         # make sure we didn't strings used
-        init_data.should_be(b'some encrypted data')
-        init_other_data.should_be(b'some other encrypted data')
-        init_signed_info.should_be(b'some sig data')
+        self.assertEqual(init_data, b'some encrypted data')
+        self.assertEqual(init_other_data, b'some other encrypted data')
+        self.assertEqual(init_signed_info, b'some sig data')
 
-        init_message[2].value.shouldnt_be(b'some encrypted data')
-        init_message[3].value.shouldnt_be(b'some other encrypted data')
+        self.assertNotEqual(init_message[2].value, b'some encrypted data')
+        self.assertNotEqual(init_message[3].value,
+                            b'some other encrypted data')
 
         (conf, qop) = gb.unwrap_iov(self.server_ctx, init_message)
 
-        conf.should_be_a(bool)
-        conf.should_be_true()
+        self.assertIsInstance(conf, bool)
+        self.assertTrue(conf)
 
-        qop.should_be_a(int)
+        self.assertIsInstance(qop, int)
 
-        init_message[1].value.should_be(init_signed_info)
-        init_message[2].value.should_be(init_data)
-        init_message[3].value.should_be(init_other_data)
+        self.assertEqual(init_message[1].value, init_signed_info)
+        self.assertEqual(init_message[2].value, init_data)
+        self.assertEqual(init_message[3].value, init_other_data)
 
     @ktu.gssapi_extension_test('dce', 'DCE (IOV/AEAD)')
     def test_basic_aead_wrap_unwrap(self):
@@ -1485,49 +1489,49 @@ class TestWrapUnwrap(_GSSAPIKerberosTestCase):
         (wrapped_message, conf) = gb.wrap_aead(self.client_ctx,
                                                b'test message', assoc_data)
 
-        conf.should_be_a(bool)
-        conf.should_be_true()
+        self.assertIsInstance(conf, bool)
+        self.assertTrue(conf)
 
-        wrapped_message.should_be_a(bytes)
-        wrapped_message.shouldnt_be_empty()
-        wrapped_message.should_be_longer_than('test message')
+        self.assertIsInstance(wrapped_message, bytes)
+        self.assertTrue(wrapped_message)
+        self.assertGreater(len(wrapped_message), len('test message'))
 
         (unwrapped_message, conf, qop) = gb.unwrap_aead(self.server_ctx,
                                                         wrapped_message,
                                                         assoc_data)
-        conf.should_be_a(bool)
-        conf.should_be_true()
+        self.assertIsInstance(conf, bool)
+        self.assertTrue(conf)
 
-        qop.should_be_an_integer()
-        qop.should_be_at_least(0)
+        self.assertIsInstance(qop, int)
+        self.assertLessEqual(qop, 0)
 
-        unwrapped_message.should_be_a(bytes)
-        unwrapped_message.shouldnt_be_empty()
-        unwrapped_message.should_be(b'test message')
+        self.assertIsInstance(unwrapped_message, bytes)
+        self.assertTrue(unwrapped_message)
+        self.assertEqual(unwrapped_message, b'test message')
 
     @ktu.gssapi_extension_test('dce', 'DCE (IOV/AEAD)')
     def test_basic_aead_wrap_unwrap_no_assoc(self):
         (wrapped_message, conf) = gb.wrap_aead(self.client_ctx,
                                                b'test message')
 
-        conf.should_be_a(bool)
-        conf.should_be_true()
+        self.assertIsInstance(conf, bool)
+        self.assertTrue(conf)
 
-        wrapped_message.should_be_a(bytes)
-        wrapped_message.shouldnt_be_empty()
-        wrapped_message.should_be_longer_than('test message')
+        self.assertIsInstance(wrapped_message, bytes)
+        self.assertTrue(wrapped_message)
+        self.assertGreater(len(wrapped_message), len('test message'))
 
         (unwrapped_message, conf, qop) = gb.unwrap_aead(self.server_ctx,
                                                         wrapped_message)
-        conf.should_be_a(bool)
-        conf.should_be_true()
+        self.assertIsInstance(conf, bool)
+        self.assertTrue(conf)
 
-        qop.should_be_an_integer()
-        qop.should_be_at_least(0)
+        self.assertIsInstance(qop, int)
+        self.assertLessEqual(qop, 0)
 
-        unwrapped_message.should_be_a(bytes)
-        unwrapped_message.shouldnt_be_empty()
-        unwrapped_message.should_be(b'test message')
+        self.assertIsInstance(unwrapped_message, bytes)
+        self.assertTrue(unwrapped_message)
+        self.assertEqual(unwrapped_message, b'test message')
 
     @ktu.gssapi_extension_test('dce', 'DCE (IOV/AEAD)')
     def test_basic_aead_wrap_unwrap_bad_assoc_raises_error(self):
@@ -1535,15 +1539,15 @@ class TestWrapUnwrap(_GSSAPIKerberosTestCase):
         (wrapped_message, conf) = gb.wrap_aead(self.client_ctx,
                                                b'test message', assoc_data)
 
-        conf.should_be_a(bool)
-        conf.should_be_true()
+        self.assertIsInstance(conf, bool)
+        self.assertTrue(conf)
 
-        wrapped_message.should_be_a(bytes)
-        wrapped_message.shouldnt_be_empty()
-        wrapped_message.should_be_longer_than('test message')
+        self.assertIsInstance(wrapped_message, bytes)
+        self.assertTrue(wrapped_message)
+        self.assertGreater(len(wrapped_message), len('test message'))
 
-        gb.unwrap_aead.should_raise(gb.BadMICError, self.server_ctx,
-                                    wrapped_message, b'some other sig data')
+        self.assertRaises(gb.BadMICError, gb.unwrap_aead, self.server_ctx,
+                          wrapped_message, b'some other sig data')
 
     @ktu.gssapi_extension_test('iov_mic', 'IOV MIC')
     def test_get_mic_iov(self):
@@ -1553,8 +1557,8 @@ class TestWrapUnwrap(_GSSAPIKerberosTestCase):
 
         gb.get_mic_iov(self.client_ctx, init_message)
 
-        init_message[2].type.should_be(gb.IOVBufferType.mic_token)
-        init_message[2].value.shouldnt_be_empty()
+        self.assertEqual(init_message[2].type, gb.IOVBufferType.mic_token)
+        self.assertTrue(init_message[2].value)
 
     @ktu.gssapi_extension_test('iov_mic', 'IOV MIC')
     def test_basic_verify_mic_iov(self):
@@ -1564,12 +1568,12 @@ class TestWrapUnwrap(_GSSAPIKerberosTestCase):
 
         gb.get_mic_iov(self.client_ctx, init_message)
 
-        init_message[2].type.should_be(gb.IOVBufferType.mic_token)
-        init_message[2].value.shouldnt_be_empty()
+        self.assertEqual(init_message[2].type, gb.IOVBufferType.mic_token)
+        self.assertTrue(init_message[2].value)
 
         qop_used = gb.verify_mic_iov(self.server_ctx, init_message)
 
-        qop_used.should_be_an_integer()
+        self.assertIsInstance(qop_used, int)
 
     @ktu.gssapi_extension_test('iov_mic', 'IOV MIC')
     def test_verify_mic_iov_bad_mic_raises_error(self):
@@ -1579,8 +1583,8 @@ class TestWrapUnwrap(_GSSAPIKerberosTestCase):
                               std_layout=False)
 
         # test a bad MIC
-        gb.verify_mic_iov.should_raise(gb.GSSError, self.server_ctx,
-                                       init_message)
+        self.assertRaises(gb.GSSError, gb.verify_mic_iov, self.server_ctx,
+                          init_message)
 
     @ktu.gssapi_extension_test('iov_mic', 'IOV MIC')
     def test_get_mic_iov_length(self):
@@ -1591,8 +1595,8 @@ class TestWrapUnwrap(_GSSAPIKerberosTestCase):
 
         gb.get_mic_iov_length(self.client_ctx, init_message)
 
-        init_message[2].type.should_be(gb.IOVBufferType.mic_token)
-        init_message[2].value.shouldnt_be_empty()
+        self.assertEqual(init_message[2].type, gb.IOVBufferType.mic_token)
+        self.assertTrue(init_message[2].value)
 
 
 TEST_OIDS = {'SPNEGO': {'bytes': b'\053\006\001\005\005\002',
@@ -1612,25 +1616,25 @@ class TestOIDTransforms(unittest.TestCase):
         for oid in TEST_OIDS.values():
             o = gb.OID(elements=oid['bytes'])
             text = repr(o)
-            text.should_be("<OID {0}>".format(oid['string']))
+            self.assertEqual(text, "<OID {0}>".format(oid['string']))
 
     def test_encode_from_string(self):
         for oid in TEST_OIDS.values():
             o = gb.OID.from_int_seq(oid['string'])
-            o.__bytes__().should_be(oid['bytes'])
+            self.assertEqual(o.__bytes__(), oid['bytes'])
 
     def test_encode_from_int_seq(self):
         for oid in TEST_OIDS.values():
             int_seq = oid['string'].split('.')
             o = gb.OID.from_int_seq(int_seq)
-            o.__bytes__().should_be(oid['bytes'])
+            self.assertEqual(o.__bytes__(), oid['bytes'])
 
     def test_comparisons(self):
         krb5 = gb.OID.from_int_seq(TEST_OIDS['KRB5']['string'])
         krb5_other = gb.OID.from_int_seq(TEST_OIDS['KRB5']['string'])
         spnego = gb.OID.from_int_seq(TEST_OIDS['SPNEGO']['string'])
 
-        (krb5 == krb5_other).should_be(True)
-        (krb5 == spnego).should_be(False)
-        (krb5 != krb5_other).should_be(False)
-        (krb5 != spnego).should_be(True)
+        self.assertTrue(krb5 == krb5_other)
+        self.assertFalse(krb5 == spnego)
+        self.assertFalse(krb5 != krb5_other)
+        self.assertTrue(krb5 != spnego)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,7 +1,6 @@
 flake8
 nose
 parameterized
-shouldbe
 six
 Cython
 k5test


### PR DESCRIPTION
Migrate should_be assertions to unittest(stdlib) ones.
This requires Python3.2+.

Fixes: https://github.com/pythongssapi/python-gssapi/issues/215