### PR TITLE
Fix shlex.split on windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,8 +37,9 @@ def get_output(*args, **kwargs):
 
 
 # get the compile and link args
+posix = os.name != 'nt'
 link_args, compile_args = [
-    shlex.split(os.environ[e]) if e in os.environ else None
+    shlex.split(os.environ[e], posix=posix) if e in os.environ else None
     for e in ['GSSAPI_LINKER_ARGS', 'GSSAPI_COMPILER_ARGS']
 ]
 


### PR DESCRIPTION
I'm trying to compile this package on Windows for [`conda-forge`](https://conda-forge.org/) so need to pass in the `GSSAPI_LINKER_ARGS` and `GSSAPI_COMPILER_ARGS` env vars. Unfortunately they're specified using the Windows backslash convention for paths which requires passing the `posix=False` argument to `shlex.split`