### PR TITLE
Don't use Github Actions's container integration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,10 +11,6 @@
     "jobs": {
         "linux": {
             "runs-on": "ubuntu-latest",
-            "container": {
-                "image": "${{ matrix.distro }}",
-                "options": "-htest.box",
-            },
             "strategy": {
                 "fail-fast": false,
                 "matrix": {
@@ -49,8 +45,9 @@
                 },
                 {
                     "name": "Build and test gssapi",
-                    "run": "./ci/build.sh",
+                    "run": "./ci/run-on-linux.sh ./ci/build.sh",
                     "env": {
+                        "DISTRO": "${{ matrix.distro }}",
                         "KRB5_VER": "${{ matrix.krb5_ver }}",
                         "FLAKE": "${{ matrix.flake }}",
                     },

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -4,10 +4,6 @@
     "jobs": {
         "update-pages": {
             "runs-on": "ubuntu-latest",
-            "container": {
-                "image": "fedora:latest",
-                "options": "-htest.box",
-            },
             "steps": [
                 {
                     "name": "Check out code",
@@ -15,7 +11,7 @@
                 },
                 {
                     "name": "Build docs",
-                    "run": "./ci/before-docs-deploy.sh",
+                    "run": "./ci/run-on-linux.sh ./ci/before-docs-deploy.sh",
                 },
                 {
                     "name": "Deploy latest docs",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,6 @@
     "jobs": {
         "release-linux": {
             "runs-on": "ubuntu-latest",
-            "container": {
-                "image": "fedora:latest",
-                "options": "-htest.box",
-            },
             "steps": [
                 {
                     "name": "Check out code",
@@ -15,7 +11,8 @@
                 },
                 {
                     "name": "Set things up",
-                    "run": "./ci/before-deploy.sh",
+                    "env": { "DISTRO": "fedora:latest" },
+                    "run": "./ci/run-on-linux.sh ./ci/before-deploy.sh",
                 },
                 {
                     "name": "Deploy to PyPI",

--- a/ci/run-on-linux.sh
+++ b/ci/run-on-linux.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -ex
+
+# If we try to use a normal Github Actions container with
+# github-pages-deploy-action, it will fail due to inability to find git.
+
+docker run -h test.box \
+       -v `pwd`:/tmp/build -w /tmp/build \
+       -e KRB5_VER=${KRB5_VER:-mit} \
+       -e FLAKE=${FLAKE:no} \
+       $DISTRO /bin/bash -ex $@


### PR DESCRIPTION
The odd way integrations don't interact meant that the deploy pipeline
couldn't find git, but we were left with no way to install git for it.

Partially reverts 93ce057b1c00b17a898db96ab716139b9121cd3c .

Signed-off-by: Robbie Harwood <rharwood@redhat.com>