### PR TITLE
Document how to use a non-detected Kerberos lib

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -68,6 +68,16 @@ Easy Way
 
     $ pip install gssapi
 
+You can also use a specific Kerberos library by defining the `GSSAPI_*`
+environment variables:
+
+.. code-block:: bash
+
+    $ export PATH=/path/to/where/krb5-config/is:$PATH
+    $ export GSSAPI_LINKER_ARGS="$(krb5-config --libs gssapi)"
+    $ export GSSAPI_COMPILER_ARGS="$(krb5-config --cflags gssapi)"
+    $ export GSSAPI_MAIN_LIB="/path/to/where/libgss{{api,-3}.dll,api.{so,dylib}}/is"
+
 From the Git Repo
 -----------------
 


### PR DESCRIPTION
Not sure about the placing or wording.

You can specify it both when you install it via pip but also when you install it from source. What do you think?

I was looking for this docs when I first tried to troubleshoot the macOS 11 issues but I couldn't figure it out. Thanks @jborean93 for mentioning it!