### PR TITLE
Add support for GSS_C_CHANNEL_BOUND_FLAG

### DIFF
--- a/gssapi/raw/types.pyx
+++ b/gssapi/raw/types.pyx
@@ -62,6 +62,10 @@ class RequirementFlag(IntEnum, metaclass=ExtendableEnum):
     # support it will ignore it.
     ok_as_delegate = 32768
 
+    # GSS_C_CHANNEL_BOUND_FLAG, implemented in MIT krb5-1.19
+    # See draft-ietf-kitten-channel-bound-flag-04
+    channel_bound = 2048
+
 
 class AddressType(IntEnum, metaclass=ExtendableEnum):
     """


### PR DESCRIPTION
MIT krb5 version 1.19 will set GSS_C_CHANNEL_BOUND_FLAG when channel
binding succeeds. This will cause gssapi to fail with the error message:

ValueError: 2048 is not a valid RequirementFlag

Add support for GSS_C_CHANNEL_BOUND_FLAG to fix this.