### PR TITLE
Fix python_requires to valid PEP 440 syntax

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -346,7 +346,7 @@ setup(
     long_description=long_desc,
     license='LICENSE.txt',
     url="https://github.com/pythongssapi/python-gssapi",
-    python_requires=">=3.6.*",
+    python_requires=">=3.6",
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Programming Language :: Python',


### PR DESCRIPTION
As reported in https://github.com/python-poetry/poetry/issues/4201 the existing `python_requires` valid of `>=3.6.*` is invalid and should be `>=3.6`. PEP440 only states that the wildcard suffix is used with [version matching `==`](https://www.python.org/dev/peps/pep-0440/#version-matching). The [ordered](https://www.python.org/dev/peps/pep-0440/#inclusive-ordered-comparison) sections do not state it allows the same rules as `==` unlike the section for `!=` does.

This still seems to work fine with `pip` luckily but tools like `poetry` seem to be a bit more strict in the intepretation and the upcoming version will error if they encounter this syntax https://github.com/python-poetry/poetry/issues/4201.