### PR TITLE
Fix Windows 32bit releasing

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -35,13 +35,10 @@ if [ $BUILD_RES -ne 0 ]; then
     exit $BUILD_RES
 fi
 
+# Only call exit on failures so we can source this script
 if [ x"$KRB5_VER" = "xheimdal" ] || [ "$OS_NAME" = "windows" ]; then
     # heimdal/Windows can't run the tests yet, so just make sure it imports and exit
-    python -c "import gssapi"
-    exit $?
+    python -c "import gssapi" || exit $?
+else
+    python setup.py nosetests --verbosity=3 || exit $?
 fi
-
-python setup.py nosetests --verbosity=3
-TEST_RES=$?
-
-exit $TEST_RES

--- a/ci/release-win.sh
+++ b/ci/release-win.sh
@@ -1,13 +1,6 @@
 #!/bin/bash -e
 
-source ./ci/lib-setup.sh
-source ./ci/lib-deploy.sh
-
-./ci/build.sh
-
-# Sigh, go find paths again
-export PATH="/c/Program Files/MIT/Kerberos/bin:"\
-   "/c/Program Files (x86)/MIT/Kerberos/bin:$PATH"
+source ./ci/build.sh
 
 # build the wheel
 python -m pip install wheel


### PR DESCRIPTION
Sourcing build.sh instead of executing it keeps the PATH changes around so the proper version of MIT Kerberos is automatically selected.