### PR TITLE
Use stale action over deprecated workflow

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,7 +1,0 @@
-# TODO: This is marked as deprecated - migrate to https://github.com/actions/stale
-# https://github.com/marketplace/actions/stale-for-actions
-daysUntilStale: 28
-daysUntilClose: 14
-staleLabel: stale
-markComment: 'false'
-only: pulls

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,23 @@
+workflow-dispatchname: Stale pull request handler
+on:
+  schedule:
+  - cron: 0 0 * * *
+
+permissions:
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/stale@main
+      id: stale
+      with:
+        days-before-stale: -1
+        days-before-pr-stable: 28
+        days-before-pr-close: 14
+        stale-pr-label: stale
+        stale-pr-message: >-
+          This pull request is stale because it has been open for 4 weeks with no activity.
+          Remove stale label or comment or this will be closed in 2 weeks.


### PR DESCRIPTION
The [Stale for Actions](https://github.com/marketplace/actions/stale-for-actions) setup that was being used has been marked as deprecated in favour of [Close Stale Issues](https://github.com/marketplace/actions/close-stale-issues#days-before-stale). This PR migrates across to the new setup with the same settings.