### PR TITLE
Fix README.rst symlink in GitHub release asset

### DIFF
--- a/ci/before-deploy.sh
+++ b/ci/before-deploy.sh
@@ -48,5 +48,22 @@ fi
 
 PKG_NAME_VER="python-gssapi-${PYTHON_GSSAPI_VERSION}"
 
-tar -czvf ./tag_build/${PKG_NAME_VER}.tar.gz --exclude='dist' --exclude='tag_build' --exclude='.git' --exclude='travis_docs_build' --exclude='.git' --transform "s,^\.,${PKG_NAME_VER}," .
+tar -cvf ./tag_build/${PKG_NAME_VER}.tar \
+    --exclude='dist' \
+    --exclude='tag_build' \
+    --exclude='.git' \
+    --exclude='travis_docs_build' \
+    --exclude='README.rst' \
+    --transform="s,^\.,${PKG_NAME_VER}," .
+
+# --transform clobbers symlink so add it last using Python
+python - << EOF
+import tarfile
+
+with tarfile.open("tag_build/${PKG_NAME_VER}.tar", mode="a:") as tf:
+    tf.add("README.rst", arcname="${PKG_NAME_VER}/README.rst")
+EOF
+
+gzip ./tag_build/${PKG_NAME_VER}.tar
+
 sha512sum --binary ./tag_build/${PKG_NAME_VER}.tar.gz > ./tag_build/${PKG_NAME_VER}.sha512sum


### PR DESCRIPTION
Fixes the symlink in the GitHub tar.gz release asset created during a
release. This symlink links to the README.txt file in the same directory
and should be preserved to the same target when extracting.

Signed-off-by: Jordan Borean <jborean93@gmail.com>

Fixes https://github.com/pythongssapi/python-gssapi/issues/103