### PR TITLE
Fix sha512sum file generation

### DIFF
--- a/ci/before-deploy.sh
+++ b/ci/before-deploy.sh
@@ -57,7 +57,8 @@ with tarfile.open("tag_build/${PKG_NAME_VER}.tar", mode="a:") as tf:
     tf.add("README.rst", arcname="${PKG_NAME_VER}/README.rst")
 EOF
 
-gzip ./tag_build/${PKG_NAME_VER}.tar
+pushd ./tag_build
+gzip ${PKG_NAME_VER}.tar
 
-sha512sum --binary ./tag_build/${PKG_NAME_VER}.tar.gz > ./tag_build/${PKG_NAME_VER}.sha512sum
-
+sha512sum --binary ${PKG_NAME_VER}.tar.gz > ${PKG_NAME_VER}.sha512sum
+popd


### PR DESCRIPTION
Change sha512sum command line so that it does not include subdirectory paths with the filename in the generated file, as that makes it harder to check the sha512sum later via the --check option.