### PR TITLE
Fix up CI containers and stop using nose

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
         name:
         - debian-stable
         - debian-heimdal
-        - centos-8
+        - centos-stream-8
         - fedora-latest
         include:
         - name: debian-stable
@@ -22,8 +22,8 @@ jobs:
         - name: debian-heimdal
           distro: debian:stable
           krb5_ver: heimdal
-        - name: centos-8
-          distro: centos:8
+        - name: centos-stream-8
+          distro: quay.io/centos/centos:stream8
         - name: fedora-latest
           distro: fedora:latest
           flake: 'yes'

--- a/README.txt
+++ b/README.txt
@@ -48,8 +48,6 @@ To compile from scratch, you will need Cython >= 0.21.1.
 For Running the Tests
 ---------------------
 
-* the `nose` package
-
 * the `k5test` package
 
 To install test dependencies using pip:

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -40,5 +40,5 @@ if [ "$OS_NAME" = "windows" ]; then
     # Windows can't run the tests yet, so just make sure it imports and exit
     python -c "import gssapi" || exit $?
 else
-    python setup.py nosetests --verbosity=3 || exit $?
+    python -m unittest -v || exit $?
 fi

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,4 @@
 flake8
-nose
 parameterized
 Cython
 k5test

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,6 @@ envlist = py36,py37,py38
 whitelist_externals=bash
 commands =
     bash -c "source ./.travis/lib-verify.sh && verify::flake8"
-    python setup.py nosetests []
+    python -m unittest
 
 deps = -r{toxinidir}/test-requirements.txt


### PR DESCRIPTION
Drop nose from the test runner as it is not needed and change the container to CentOS 8 stream as CentOS 8 went EOL.