### PR TITLE
Fix up doc type ambiguity

### DIFF
--- a/gssapi/raw/named_tuples.py
+++ b/gssapi/raw/named_tuples.py
@@ -1,31 +1,27 @@
 from typing import Iterable, List, NamedTuple, Optional, Set, TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from gssapi.raw.creds import Creds
-    from gssapi.raw.names import Name
-    from gssapi.raw.oids import OID
-    from gssapi.raw.sec_contexts import SecurityContext
-    from gssapi.raw.types import RequirementFlag
+    import gssapi.raw as g
 
 
 class AcquireCredResult(NamedTuple):
     """Credential result when acquiring a GSSAPI credential."""
-    creds: "Creds"  #: GSSAPI credentials that were acquired
-    mechs: Set["OID"]  #: Set of mechs the cred is for
+    creds: "g.Creds"  #: GSSAPI credentials that were acquired
+    mechs: Set["g.OID"]  #: Set of mechs the cred is for
     lifetime: int  #: Number of seconds for which the cred will remain valid
 
 
 class InquireCredResult(NamedTuple):
     """Information about the credential."""
-    name: Optional["Name"]  #: The principal associated with the credential
+    name: Optional["g.Name"]  #: The principal associated with the credential
     lifetime: Optional[int]  #: Number of seconds which the cred is valid for
     usage: Optional[str]  #: How the credential can be used
-    mechs: Optional[Set["OID"]]  #: Set of mechs the cred is for
+    mechs: Optional[Set["g.OID"]]  #: Set of mechs the cred is for
 
 
 class InquireCredByMechResult(NamedTuple):
     """Information about the credential for a specific mechanism."""
-    name: Optional["Name"]  #: The principal associated with the credential
+    name: Optional["g.Name"]  #: The principal associated with the credential
     init_lifetime: Optional[int]  #: Time valid for initiation
     accept_lifetime: Optional[int]  #: Time valid for accepting
     usage: Optional[str]  #: How the credential can be used
@@ -33,8 +29,8 @@ class InquireCredByMechResult(NamedTuple):
 
 class AddCredResult(NamedTuple):
     """Result of adding to a GSSAPI credential."""
-    creds: Optional["Creds"]  #: The credential that was generated
-    mechs: Set["OID"]  #: Set of mechs the cred is for
+    creds: Optional["g.Creds"]  #: The credential that was generated
+    mechs: Set["g.OID"]  #: Set of mechs the cred is for
     init_lifetime: int  #: Time valid for initiation
     accept_lifetime: int  #: Time valid for accepting
 
@@ -42,7 +38,7 @@ class AddCredResult(NamedTuple):
 class DisplayNameResult(NamedTuple):
     """Textual representation of a GSSAPI name."""
     name: bytes  #: The representation of the GSSAPI name
-    name_type: Optional["OID"]  #: The type of GSSAPI name
+    name_type: Optional["g.OID"]  #: The type of GSSAPI name
 
 
 class WrapResult(NamedTuple):
@@ -60,21 +56,21 @@ class UnwrapResult(NamedTuple):
 
 class AcceptSecContextResult(NamedTuple):
     """Result when accepting a security context by an initiator."""
-    context: "SecurityContext"  #: The acceptor security context
-    initiator_name: "Name"  #: The authenticated name of the initiator
-    mech: "OID"  #: Mechanism with which the context was established
+    context: "g.SecurityContext"  #: The acceptor security context
+    initiator_name: "g.Name"  #: The authenticated name of the initiator
+    mech: "g.OID"  #: Mechanism with which the context was established
     token: Optional[bytes]  #: Token to be returned to the initiator
-    flags: "RequirementFlag"  #: Services requested by the initiator
+    flags: "g.equirementFlag"  #: Services requested by the initiator
     lifetime: int  #: Seconds for which the context is valid for
-    delegated_creds: Optional["Creds"]  #: Delegated credentials
+    delegated_creds: Optional["g.Creds"]  #: Delegated credentials
     more_steps: bool  #: More input is required to complete the exchange
 
 
 class InitSecContextResult(NamedTuple):
     """Result when initiating a security context"""
-    context: "SecurityContext"  #: The initiator security context
-    mech: "OID"  #: Mechanism used in the security context
-    flags: "RequirementFlag"  #: Services available for the context
+    context: "g.SecurityContext"  #: The initiator security context
+    mech: "g.OID"  #: Mechanism used in the security context
+    flags: "g.RequirementFlag"  #: Services available for the context
     token: Optional[bytes]  #: Token to be sent to the acceptor
     lifetime: int  #: Seconds for which the context is valid for
     more_steps: bool  #: More input is required to complete the exchange
@@ -82,18 +78,18 @@ class InitSecContextResult(NamedTuple):
 
 class InquireContextResult(NamedTuple):
     """Information about the security context."""
-    initiator_name: Optional["Name"]  #: Name of the initiator
-    target_name: Optional["Name"]  #: Name of the acceptor
+    initiator_name: Optional["g.Name"]  #: Name of the initiator
+    target_name: Optional["g.Name"]  #: Name of the acceptor
     lifetime: Optional[int]  #: Time valid for the security context
-    mech: Optional["OID"]  #: Mech used to create the security context
-    flags: Optional["RequirementFlag"]  #: Services available for the context
+    mech: Optional["g.OID"]  #: Mech used to create the security context
+    flags: Optional["g.RequirementFlag"]  #: Services available for the context
     locally_init: Optional[bool]  #: Context was initiated locally
     complete: Optional[bool]  #: Context has been established and ready to use
 
 
 class StoreCredResult(NamedTuple):
     """Result of the credential storing operation."""
-    mechs: List["OID"]  #: Mechs that were stored in the credential store
+    mechs: List["g.OID"]  #: Mechs that were stored in the credential store
     usage: str  #: How the credential can be used
 
 
@@ -107,7 +103,7 @@ class InquireNameResult(NamedTuple):
     """Information about a GSSAPI Name."""
     attrs: List[bytes]  #: Set of attribute names
     is_mech_name: bool  #: Name is a mechanism name
-    mech: "OID"  #: The mechanism if is_name_mech is True
+    mech: "g.OID"  #: The mechanism if is_name_mech is True
 
 
 class GetNameAttributeResult(NamedTuple):
@@ -120,8 +116,8 @@ class GetNameAttributeResult(NamedTuple):
 
 class InquireAttrsResult(NamedTuple):
     """Set of attributes supported and known by a mechanism."""
-    mech_attrs: Set["OID"]  #: The mechanisms attributes
-    known_mech_attrs: Set["OID"]  #: Known attributes of the mechanism
+    mech_attrs: Set["g.OID"]  #: The mechanisms attributes
+    known_mech_attrs: Set["g.OID"]  #: Known attributes of the mechanism
 
 
 class DisplayAttrResult(NamedTuple):


### PR DESCRIPTION
Seems like a new Sphinx build has problems trying to determine what some of the annotated types are in `named_tuples.py`. This change ensures it uses the full import as a reference to avoid the warnings.