### PR TITLE
Bump version to 1.8.1 with Python 3.7 requires

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,6 @@ jobs:
           version: cp38-macosx_arm64
         - os: macOS-12
           version: cp37-macosx_x86_64
-        - os: macOS-12
-          version: cp36-macosx_x86_64
 
         - os: windows-2022
           version: cp310-win_amd64
@@ -76,10 +74,6 @@ jobs:
           version: cp37-win_amd64
         - os: windows-2022
           version: cp37-win32
-        - os: windows-2022
-          version: cp36-win_amd64
-        - os: windows-2022
-          version: cp36-win32
 
     steps:
     - name: Set up environment
@@ -136,7 +130,7 @@ jobs:
         name:
         - debian-stable
         - debian-heimdal
-        - centos-stream-8
+        - centos-stream-9
         - fedora-latest
         include:
         - name: debian-stable
@@ -144,8 +138,8 @@ jobs:
         - name: debian-heimdal
           distro: debian:stable
           krb5_ver: heimdal
-        - name: centos-stream-8
-          distro: quay.io/centos/centos:stream8
+        - name: centos-stream-9
+          distro: quay.io/centos/centos:stream9
         - name: fedora-latest
           distro: fedora:latest
           flake: 'yes'
@@ -181,7 +175,6 @@ jobs:
         - win-py-3.9
         - win-py-3.8
         - win-py-3.7
-        - win-py-3.6
         arch:
         - x64
         - x86
@@ -194,8 +187,6 @@ jobs:
           pyenv: '3.8'
         - name: win-py-3.7
           pyenv: '3.7'
-        - name: win-py-3.6
-          pyenv: '3.6'
 
     steps:
     - name: Check out code

--- a/README.txt
+++ b/README.txt
@@ -36,14 +36,15 @@ Basic
 
 * a C compiler (such as GCC)
 
-* Python 3.6+ (older releases support older versions, but are unsupported)
+* Python 3.7+ (older releases support older versions, but are unsupported)
 
 * the `decorator` python package
 
 Compiling from Scratch
 ----------------------
 
-To compile from scratch, you will need Cython >= 0.21.1.
+To compile from scratch, you will need Cython >= 0.29.29 which is automatically
+installed by pip in an isolated build virtual environment.
 
 For Running the Tests
 ---------------------

--- a/setup.py
+++ b/setup.py
@@ -274,7 +274,7 @@ install_requires = [
 
 setup(
     name='gssapi',
-    version='1.8.0',
+    version='1.8.1',
     author='The Python GSSAPI Team',
     author_email='jborean93@gmail.com',
     packages=['gssapi', 'gssapi.raw', 'gssapi.raw._enum_extensions',
@@ -287,12 +287,11 @@ setup(
     long_description=long_desc,
     license='LICENSE.txt',
     url="https://github.com/pythongssapi/python-gssapi",
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',


### PR DESCRIPTION
This update bumps the `python_requires` to be `>=3.7` as the sdist build
requires PEP 517 support that is somewhat only guaranteed with the pip
that was shipped with Python 3.7 or greater. Since 3.6 has been end of
life since December 2021 and the remaining Linux distributions that
still use it have system provided packages this shouldn't be a surprise.

Fixes https://github.com/pythongssapi/python-gssapi/issues/299

Signed-off-by: Jordan Borean <jborean93@gmail.com>