### PR TITLE
Bump GHA actions to latest version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     
     - name: Select python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
 
@@ -28,7 +28,7 @@ jobs:
         GSSAPI_COMPILER_ARGS: ''
 
     - name: Upload sdist
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: artifact
         path: ./dist/*.tar.gz
@@ -99,7 +99,7 @@ jobs:
         echo "C:\Program Files${{ endsWith(matrix.version, '-win32') && ' (x86)' || '' }}\MIT\Kerberos\bin;$PATH" >> $GITHUB_PATH
 
     - name: Download gssapi sdist
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: artifact
         path: ./
@@ -121,7 +121,7 @@ jobs:
         CIBW_BUILD_VERBOSITY: 1
 
     - name: Upload wheel
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         path: ./wheelhouse/*.whl
         name: artifact
@@ -154,10 +154,10 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Download built project
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: artifact
         path: ./dist
@@ -201,16 +201,16 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Download built project
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: artifact
         path: ./dist
 
     - name: Install the right python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.pyenv }}
         architecture: ${{ matrix.arch }}
@@ -229,10 +229,10 @@ jobs:
     runs-on: macos-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Download built project
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: artifact
         path: ./dist
@@ -253,10 +253,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Download built project
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: artifact
         path: ./dist
@@ -268,21 +268,21 @@ jobs:
 
     - name: Get tarball path
       id: tarball
-      run: echo "::set-output name=tarball::`ls tag_build/*.tar.gz | awk -F/ '{print $2}'`"
+      run: echo "tarball=`ls tag_build/*.tar.gz | awk -F/ '{print $2}'`" >> $GITHUB_OUTPUT
 
     - name: Get release checksum path
       id: checksum
-      run: echo "::set-output name=checksum::`ls tag_build/*.sha512sum | awk -F/ '{print $2}'`"
+      run: echo "checksum=`ls tag_build/*.sha512sum | awk -F/ '{print $2}'`" >> $GITHUB_OUTPUT
 
     - name: Upload tagged build artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         path: tag_build/${{ steps.tarball.outputs.tarball }}
         name: artifact
 
     - name: Deploy stable docs
       if: startsWith(github.ref, 'refs/tags/v')
-      uses: JamesIves/github-pages-deploy-action@3.7.1
+      uses: JamesIves/github-pages-deploy-action@4.4.1
       with:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         BRANCH: gh-pages
@@ -323,7 +323,7 @@ jobs:
 
     - name: Deploy to PyPI
       if: startsWith(github.ref, 'refs/tags/v')
-      uses: pypa/gh-action-pypi-publish@v1.1.0
+      uses: pypa/gh-action-pypi-publish@v1.5.1
       with:
         user: __token__
         password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
The release management actions might need to be changed in the future to something else. They are unmaintained at the present.

Signed-off-by: Jordan Borean <jborean93@gmail.com>