### PR TITLE
Fix Cython 3 Compatibility

### DIFF
--- a/gssapi/raw/_enum_extensions/ext_dce.pyx
+++ b/gssapi/raw/_enum_extensions/ext_dce.pyx
@@ -1,6 +1,6 @@
 from gssapi.raw.cython_types cimport OM_uint32
 
-import gssapi.raw._enum_extensions as ext_registry
+from gssapi.raw import _enum_extensions as ext_registry
 
 
 cdef extern from "python_gssapi_ext.h":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "Cython >= 0.29.29, < 3.0.0",  # 0.29.29 includes fixes for Python 3.11
+    "Cython >= 0.29.29, < 4.0.0",  # 0.29.29 includes fixes for Python 3.11
     "setuptools >= 40.6.0",  # Start of PEP 517 support for setuptools
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -274,7 +274,7 @@ install_requires = [
 
 setup(
     name='gssapi',
-    version='1.8.2',
+    version='1.8.3',
     author='The Python GSSAPI Team',
     author_email='jborean93@gmail.com',
     packages=['gssapi', 'gssapi.raw', 'gssapi.raw._enum_extensions',


### PR DESCRIPTION
Fixes compatibility with Cython 3 by fixing up the import so it doesn't try and do a recursive import. This also increases the upper bound for Cython to 4.0.0 now that 3.0.0 is compatible.

Fixes: https://github.com/pythongssapi/python-gssapi/issues/319