### PR TITLE
Add basic import with assertions check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,43 @@ jobs:
         path: ./wheelhouse/*.whl
         name: artifact
 
+  # To catch issues like this https://github.com/pythongssapi/python-gssapi/issues/327
+  assertion_build:
+    needs:
+    - build_sdist
+
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download gssapi sdist
+      uses: actions/download-artifact@v3
+      with:
+        name: artifact
+        path: ./dist
+
+    - name: Compile Python with assertions
+      shell: bash
+      run: |
+        PYTHON_VERSION="3.11.5"
+        wget --quiet "https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tar.xz"
+        tar xf "Python-${PYTHON_VERSION}.tar.xz"
+        cd "Python-${PYTHON_VERSION}/"
+        ./configure --with-assertions --prefix "${PWD}/../Python-${PYTHON_VERSION}-build"
+        make
+        make install
+        cd ..
+
+        sudo apt-get update
+        DEBIAN_FRONTEND=noninteractive sudo apt-get -y install krb5-user libkrb5-dev
+
+        GSSAPI_VER="$( find ./dist -type f -name 'gssapi-*.tar.gz' -printf "%f\n" | sed -n 's/gssapi-\(.*\)\.tar\.gz/\1/p' )"
+
+        PATH="${PWD}/Python-${PYTHON_VERSION}-build/bin:${PATH}"
+        python3 -m pip install gssapi=="${GSSAPI_VER}" \
+            --find-links "file://${PWD}/dist" \
+            --verbose
+
+        python3 -c "import gssapi"
+
   linux:
     needs:
     - build_sdist
@@ -257,6 +294,7 @@ jobs:
     name: publish
 
     needs:
+    - assertion_build
     - linux
     - macos
     - windows

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 requires = [
-    "Cython >= 0.29.29, < 4.0.0",  # 0.29.29 includes fixes for Python 3.11
+    # 0.29.29 includes fixes for Python 3.11
+    # Cannot use 3 until https://github.com/cython/cython/issues/5665 is fixed
+    "Cython >= 0.29.29, < 3.0.0",
     "setuptools >= 40.6.0",  # Start of PEP 517 support for setuptools
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -274,7 +274,7 @@ install_requires = [
 
 setup(
     name='gssapi',
-    version='1.8.3',
+    version='1.8.4',
     author='The Python GSSAPI Team',
     author_email='jborean93@gmail.com',
     packages=['gssapi', 'gssapi.raw', 'gssapi.raw._enum_extensions',


### PR DESCRIPTION
This PR is designed to do basic tests with a Python build with `--with-assertions`. It also caps the Cython version to less than 3 until it fixes the issue causing the referenced issue.

Fixes: https://github.com/pythongssapi/python-gssapi/issues/327