### PR TITLE
Add custom FKW_BIN override option

### DIFF
--- a/gssapi/_win_config.py
+++ b/gssapi/_win_config.py
@@ -12,10 +12,13 @@ import sys
 import ctypes
 
 #: Path to normal KfW installed bin folder
-KFW_BIN = os.path.join(
-    os.environ.get('ProgramFiles', r'C:\Program Files'),
-    'MIT', 'Kerberos', 'bin',
-)
+if os.environ.get("KFW_BIN_PATH_OVERRIDE"):
+    KFW_BIN = os.environ.get("KFW_BIN_PATH_OVERRIDE")
+else:
+    KFW_BIN = os.path.join(
+        os.environ.get('ProgramFiles', r'C:\Program Files'),
+        'MIT', 'Kerberos', 'bin',
+    )
 #: Download location for KfW
 KFW_DL = "https://web.mit.edu/KERBEROS/dist"
 


### PR DESCRIPTION
In response to https://github.com/pythongssapi/python-gssapi/issues/290 I have added option to allow for KFW_BIN override using the environment variable "KFW_BIN_PATH_OVERRIDE". This will allow external scripts to load the required dependencies in a custom location.