### PR TITLE
Added environment variable for KFW_BIN path override

### DIFF
--- a/gssapi/_win_config.py
+++ b/gssapi/_win_config.py
@@ -12,10 +12,13 @@ import sys
 import ctypes
 
 #: Path to normal KfW installed bin folder
-KFW_BIN = os.path.join(
-    os.environ.get('ProgramFiles', r'C:\Program Files'),
-    'MIT', 'Kerberos', 'bin',
-)
+if os.environ.get("KFW_BIN_PATH_OVERRIDE"):
+    KFW_BIN = os.environ.get("KFW_BIN_PATH_OVERRIDE")
+else:
+    KFW_BIN = os.path.join(
+        os.environ.get('ProgramFiles', r'C:\Program Files'),
+        'MIT', 'Kerberos', 'bin',
+    )
 #: Download location for KfW
 KFW_DL = "https://web.mit.edu/KERBEROS/dist"
 


### PR DESCRIPTION
In response to https://github.com/pythongssapi/python-gssapi/issues/290 I have added a custom environment variable check to override the KFW_BIN path value within _win_config.py. By setting the "KFW_BIN_PATH_OVERRIDE" environment variable before gssapi is imported, external scripts can allow the KfW dependencies to be loaded from a custom location.