### PR TITLE
Enable the use of `mypy --no-explicit-reexport` on downstream projects

### DIFF
--- a/gssapi/__init__.py
+++ b/gssapi/__init__.py
@@ -38,3 +38,17 @@ from gssapi.sec_contexts import SecurityContext  # noqa
 from gssapi.mechs import Mechanism  # noqa
 
 from gssapi._utils import set_encoding  # noqa
+
+__all__ = [
+    'AddressType',
+    'Credentials',
+    'IntEnumFlagSet',
+    'Mechanism',
+    'MechType',
+    'Name',
+    'NameType',
+    'OID',
+    'RequirementFlag',
+    'SecurityContext',
+    'set_encoding',
+]


### PR DESCRIPTION
When testing simple python code like this with mypy for type-safety:

```
import gssapi
gsc:gssapi.SecurityContext
gsc = gssapi.SecurityContext(
       usage='initiate',
       name=gssapi.Name('imap@localhost',
                        gssapi.NameType.hostbased_service))
```

I see these errors:

```
0 $ mypy --no-implicit-reexport ./test.py
test.py:3: error: Name "gssapi.SecurityContext" is not defined  [name-defined]
test.py:4: error: Module "gssapi" does not explicitly export attribute "SecurityContext"  [attr-defined]
test.py:4: error: Module "gssapi" does not explicitly export attribute "Name"  [attr-defined]
test.py:4: error: Module "gssapi" does not explicitly export attribute "NameType"  [attr-defined]
Found 4 errors in 1 file (checked 1 source file)
1 $
```

The same thing happens when using `mypy --strict`.

[a blogpost](https://til.codeinthehole.com/posts/how-to-handle-convenience-imports-with-mypy/) suggested that the `__all__` variable in `gssapi/__init__.py` might be the way to fix this.

I can confirm that it does clear the error, but I'm not enough of a python module expert to know whether there might be some undesirable side effects as well to making this change.  Please review!

Tested on debian testing/unstable, with:

- python3  3.11.6-1
- python3-gssapi 1.8.2-1+b2
- mypy 1.8.0-1