### PR TITLE
Re-add support for Cython 3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     # 0.29.29 includes fixes for Python 3.11
-    # Cannot use 3 until https://github.com/cython/cython/issues/5665 is fixed
-    "Cython >= 0.29.29, < 3.0.0",
+    "Cython >= 3.0.3, < 4.0.0",
     "setuptools >= 40.6.0",  # Start of PEP 517 support for setuptools
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
https://github.com/cython/cython/issues/5665 has been fixed so it should be safe to use Cython 3 now.