### PR TITLE
Use MyST for markdown docs build

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,4 +1,4 @@
+myst-parser  # For parsing markdown docs instead of rst
 Sphinx >= 1.3.1
 sphinx-autoapi
 sphinx-rtd-theme >= 0.2.5b1
-recommonmark >= 0.4.0

--- a/docs/custom_extensions/custom_recommonmark.py
+++ b/docs/custom_extensions/custom_recommonmark.py
@@ -1,8 +1,0 @@
-from recommonmark.parser import CommonMarkParser
-from docutils import nodes
-
-# treats "verbatim" (code without a language specified) as a code sample
-class AllCodeCommonMarkParser(CommonMarkParser):
-    def verbatim(self, text):
-        node = nodes.literal_block(text, text)
-        self.current_node.append(node)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,8 +20,6 @@ import sys, os, re
 
 sys.path.insert(0, os.path.abspath('../custom_extensions'))
 
-from custom_recommonmark import AllCodeCommonMarkParser
-
 # -- General configuration -----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
@@ -30,6 +28,7 @@ from custom_recommonmark import AllCodeCommonMarkParser
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
+  'myst_parser',
   'sphinx.ext.autodoc',
   'sphinx.ext.intersphinx',
   'sphinx.ext.viewcode',
@@ -47,13 +46,10 @@ autoapi_file_patterns = ['*.pyi']
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
-# Parsers for different suffixes
-source_parsers = {
-    '.md': AllCodeCommonMarkParser
-}
-
 # The suffix of source filenames.
 source_suffix = ['.rst', '.md']
+
+myst_all_links_external = True
 
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'


### PR DESCRIPTION
Moves away from recommonmark to MyST when building the markdown docs. Recommonmark is deprecated and no longer maintained in favour of MyST. The only change here is to swap up the dependencies and enable the MyST plugin in the conf.py.

Fixes: https://github.com/pythongssapi/python-gssapi/issues/337