### PR TITLE
Update CI to build CPython 3.13 wheels & drop 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,10 @@ jobs:
       matrix:
         include:
         - os: macOS-12
+          version: cp313-macosx_x86_64
+        - os: macOS-12
+          version: cp313-macosx_arm64
+        - os: macOS-12
           version: cp312-macosx_x86_64
         - os: macOS-12
           version: cp312-macosx_arm64
@@ -63,9 +67,11 @@ jobs:
           version: cp38-macosx_x86_64
         - os: macOS-12
           version: cp38-macosx_arm64
-        - os: macOS-12
-          version: cp37-macosx_x86_64
 
+        - os: windows-2022
+          version: cp313-win_amd64
+        - os: windows-2022
+          version: cp313-win32
         - os: windows-2022
           version: cp312-win_amd64
         - os: windows-2022
@@ -86,10 +92,6 @@ jobs:
           version: cp38-win_amd64
         - os: windows-2022
           version: cp38-win32
-        - os: windows-2022
-          version: cp37-win_amd64
-        - os: windows-2022
-          version: cp37-win32
 
     steps:
     - name: Set up environment
@@ -121,7 +123,7 @@ jobs:
         rm gssapi-*.tar.gz
 
     - name: Build wheel
-      uses: pypa/cibuildwheel@v2.16.5
+      uses: pypa/cibuildwheel@v2.21.0
       env:
         CIBW_ARCHS: all
         CIBW_TEST_SKIP: '*_arm64'
@@ -225,18 +227,20 @@ jobs:
       fail-fast: false
       matrix:
         name:
+        - win-py-3.13
         - win-py-3.12
         - win-py-3.11
         - win-py-3.10
         - win-py-3.9
         - win-py-3.8
-        - win-py-3.7
         arch:
         - x64
         - x86
         include:
+        - name: win-py-3.13
+          pyenv: '3.13.0-rc.2'
         - name: win-py-3.12
-          pyenv: '3.12.0-rc.1'
+          pyenv: '3.12'
         - name: win-py-3.11
           pyenv: '3.11'
         - name: win-py-3.10
@@ -245,8 +249,6 @@ jobs:
           pyenv: '3.9'
         - name: win-py-3.8
           pyenv: '3.8'
-        - name: win-py-3.7
-          pyenv: '3.7'
 
     steps:
     - name: Check out code

--- a/README.txt
+++ b/README.txt
@@ -32,14 +32,14 @@ Basic
 
 * a C compiler (such as GCC)
 
-* Python 3.7+ (older releases support older versions, but are unsupported)
+* Python 3.8+ (older releases support older versions, but are unsupported)
 
 * the `decorator` python package
 
 Compiling from Scratch
 ----------------------
 
-To compile from scratch, you will need Cython >= 0.29.29 which is automatically
+To compile from scratch, you will need Cython ``>= 3.0.3, < 4.0.0`` which is automatically
 installed by pip in an isolated build virtual environment.
 
 For Running the Tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [build-system]
 requires = [
-    # 0.29.29 includes fixes for Python 3.11
     "Cython >= 3.0.3, < 4.0.0",
     "setuptools >= 40.6.0",  # Start of PEP 517 support for setuptools
 ]

--- a/setup.py
+++ b/setup.py
@@ -278,7 +278,7 @@ install_requires = [
 
 setup(
     name='gssapi',
-    version='1.8.4',
+    version='1.9.0',
     author='The Python GSSAPI Team',
     author_email='jborean93@gmail.com',
     packages=['gssapi', 'gssapi.raw', 'gssapi.raw._enum_extensions',
@@ -291,17 +291,17 @@ setup(
     long_description=long_desc,
     license='LICENSE.txt',
     url="https://github.com/pythongssapi/python-gssapi",
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: ISC License (ISCL)',
         'Programming Language :: Python :: Implementation :: CPython',


### PR DESCRIPTION
Updates the CI to build 3.13 wheels based on the latest RC and drop the 3.7 support and wheels.