### PR TITLE
Fix return type for name property in Credentials class.

### DIFF
--- a/gssapi/creds.py
+++ b/gssapi/creds.py
@@ -82,9 +82,9 @@ class Credentials(rcreds.Creds):
                       super(Credentials, cls).__new__(cls, base_creds))
 
     @property
-    def name(self) -> rnames.Name:
+    def name(self) -> names.Name:
         """Get the name associated with these credentials"""
-        return t.cast(rnames.Name,
+        return t.cast(names.Name,
                       self.inquire(name=True, lifetime=False, usage=False,
                                    mechs=False).name)
 

--- a/gssapi/tests/test_high_level.py
+++ b/gssapi/tests/test_high_level.py
@@ -224,6 +224,7 @@ class CredsTestCase(_GSSAPIKerberosTestCase):
 
         if kwargs['name']:
             self.assertEqual(resp.name, self.name)
+            self.assertIsInstance(resp.name, gssnames.Name)
         else:
             self.assertIsNone(resp.name)
 
@@ -250,6 +251,7 @@ class CredsTestCase(_GSSAPIKerberosTestCase):
 
         if kwargs['name']:
             self.assertEqual(resp.name, self.name)
+            self.assertIsInstance(resp.name, gssnames.Name)
         else:
             self.assertIsNone(resp.name)
 


### PR DESCRIPTION
It seems like type annotation for [name](https://github.com/pythongssapi/python-gssapi/blob/main/gssapi/creds.py#L85) property in [gssapi.creds.Credentials](https://github.com/pythongssapi/python-gssapi/blob/main/gssapi/creds.py#L17) class should be gssapi.names.Name rather than gssapi.raw.names.Name.

Because it explicitly casts in [gssapi.creds.Credentials.inquire](https://github.com/pythongssapi/python-gssapi/blob/main/gssapi/creds.py#L308).

Change return type and add checks into tests.