### PR TITLE
python-gssapi incompatible with Cython 3.1, set upper limit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "Cython >= 3.0.3, < 4.0.0",
+    "Cython >= 3.0.3, < 3.1.0",
     "setuptools >= 40.6.0",  # Start of PEP 517 support for setuptools
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Cython 3.1.0 will require C99 compatible C compiler, as per https://github.com/cython/cython/issues/6861#issuecomment-2868999325

Fixes #359