### PR TITLE
Update Python requirements and pin Cython

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Select python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.12
 
     - name: Build sdist
       run: |
@@ -44,6 +44,12 @@ jobs:
       matrix:
         include:
         - os: macOS-13
+          version: cp314-macosx_x86_64
+          prerelease: true
+        - os: macOS-15
+          version: cp314-macosx_arm64
+          prerelease: true
+        - os: macOS-13
           version: cp313-macosx_x86_64
         - os: macOS-15
           version: cp313-macosx_arm64
@@ -63,11 +69,13 @@ jobs:
           version: cp39-macosx_x86_64
         - os: macOS-15
           version: cp39-macosx_arm64
-        - os: macOS-13
-          version: cp38-macosx_x86_64
-        - os: macOS-15
-          version: cp38-macosx_arm64
 
+        - os: windows-2022
+          version: cp314-win_amd64
+          prerelease: true
+        - os: windows-2022
+          version: cp314-win32
+          prerelease: true
         - os: windows-2022
           version: cp313-win_amd64
         - os: windows-2022
@@ -88,10 +96,6 @@ jobs:
           version: cp39-win_amd64
         - os: windows-2022
           version: cp39-win32
-        - os: windows-2022
-          version: cp38-win_amd64
-        - os: windows-2022
-          version: cp38-win32
 
     steps:
     - name: Set up environment
@@ -109,7 +113,7 @@ jobs:
         echo "C:\Program Files${{ endsWith(matrix.version, '-win32') && ' (x86)' || '' }}\MIT\Kerberos\bin;$PATH" >> $GITHUB_PATH
 
     - name: Download gssapi sdist
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         name: artifact-sdist
         path: ./
@@ -123,10 +127,11 @@ jobs:
         rm gssapi-*.tar.gz
 
     - name: Build wheel
-      uses: pypa/cibuildwheel@v2.22.0
+      uses: pypa/cibuildwheel@v3.1.4
       env:
         CIBW_BUILD: ${{ matrix.version }}
         CIBW_BUILD_VERBOSITY: 1
+        CIBW_PRERELEASE_PYTHONS: ${{ matrix.prerelease || 'false' }}
 
     - name: Upload wheel
       uses: actions/upload-artifact@v4
@@ -142,7 +147,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Download gssapi sdist
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         name: artifact-sdist
         path: ./dist
@@ -166,7 +171,7 @@ jobs:
 
         PATH="${PWD}/Python-${PYTHON_VERSION}-build/bin:${PATH}"
         python3 -m pip install gssapi=="${GSSAPI_VER}" \
-            --find-links "file://${PWD}/dist" \
+            --find-links dist \
             --verbose
 
         python3 -c "import gssapi"
@@ -199,10 +204,10 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Download built project
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         pattern: artifact-*
         merge-multiple: true
@@ -225,18 +230,20 @@ jobs:
       fail-fast: false
       matrix:
         name:
+        - win-py-3.14
         - win-py-3.13
         - win-py-3.12
         - win-py-3.11
         - win-py-3.10
         - win-py-3.9
-        - win-py-3.8
         arch:
         - x64
         - x86
         include:
+        - name: win-py-3.14
+          pyenv: '3.14.0-rc.2'
         - name: win-py-3.13
-          pyenv: '3.13.0-rc.3'
+          pyenv: '3.13'
         - name: win-py-3.12
           pyenv: '3.12'
         - name: win-py-3.11
@@ -245,15 +252,13 @@ jobs:
           pyenv: '3.10'
         - name: win-py-3.9
           pyenv: '3.9'
-        - name: win-py-3.8
-          pyenv: '3.8'
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Download built project
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         pattern: artifact-*
         merge-multiple: true
@@ -279,10 +284,10 @@ jobs:
     runs-on: macos-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Download built project
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         pattern: artifact-*
         merge-multiple: true
@@ -311,10 +316,10 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Download built project
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         pattern: artifact-*
         merge-multiple: true
@@ -347,37 +352,14 @@ jobs:
         folder: ci_docs_build
         target-folder: stable
 
-    - name: Create release
+    - name: Create release with tar artifact
       if: startsWith(github.ref, 'refs/tags/v')
-      uses: actions/create-release@v1
-      id: cr
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: softprops/action-gh-release@v2
       with:
-        tag_name: ${{ github.ref }}
-        release_name: ${{ github.ref }}
-
-    - name: Upload release tarball
-      if: startsWith(github.ref, 'refs/tags/v')
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.cr.outputs.upload_url }}
-        asset_path: tag_build/${{ steps.tarball.outputs.tarball }}
-        asset_name: ${{ steps.tarball.outputs.tarball }}
-        asset_content_type: application/octet-stream
-
-    - name: Upload release checksum
-      if: startsWith(github.ref, 'refs/tags/v')
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.cr.outputs.upload_url }}
-        asset_path: tag_build/${{ steps.checksum.outputs.checksum }}
-        asset_name: ${{ steps.checksum.outputs.checksum }}
-        asset_content_type: text/plain
+        files: |
+          tag_build/${{ steps.tarball.outputs.tarball }}
+          tag_build/${{ steps.checksum.outputs.checksum }}
+        generate_release_notes: true
 
     - name: Deploy to PyPI
       if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Select python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.12
 
     - name: Build sdist
       run: |

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/stale@v9.0.0
+    - uses: actions/stale@v9.1.0
       id: stale
       with:
         days-before-stale: -1

--- a/README.txt
+++ b/README.txt
@@ -32,14 +32,14 @@ Basic
 
 * a C compiler (such as GCC)
 
-* Python 3.8+ (older releases support older versions, but are unsupported)
+* Python 3.9+ (older releases support older versions, but are unsupported)
 
 * the `decorator` python package
 
 Compiling from Scratch
 ----------------------
 
-To compile from scratch, you will need Cython ``>= 3.0.3, < 4.0.0`` which is automatically
+To compile from scratch, you will need Cython (see [pyproject.toml](pyproject.toml) for the version) which is automatically
 installed by pip in an isolated build virtual environment.
 
 For Running the Tests

--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -132,14 +132,8 @@ lib::setup::install() {
     echo "Installing gssapi"
     GSSAPI_VER="$( grep 'version=' setup.py | cut -d "'" -f2 )"
 
-    if [ "$(expr substr $(uname -s) 1 5)" == "MINGW" ]; then
-        DIST_LINK_PATH="$( echo "${PWD}/dist" | sed -e 's/^\///' -e 's/\//\\/g' -e 's/^./\0:/' )"
-    else
-        DIST_LINK_PATH="${PWD}/dist"
-    fi
-
     python -m pip install gssapi=="${GSSAPI_VER}" \
-        --find-links "file://${DIST_LINK_PATH}" \
+        --find-links dist \
         --verbose
 
     echo "Installing dev dependencies"

--- a/gssapi/names.py
+++ b/gssapi/names.py
@@ -390,8 +390,8 @@ class _NameAttributeMapping(MutableMapping):
             complete = value.complete
             attr_value = value.values
         elif isinstance(value, tuple) and len(value) == 2:
-            complete = t.cast(bool, value[1])
-            attr_value = [t.cast(bytes, value[0])]
+            complete = value[1]
+            attr_value = [value[0]]
         else:
             complete = False
 

--- a/gssapi/sec_contexts.py
+++ b/gssapi/sec_contexts.py
@@ -499,7 +499,7 @@ class SecurityContext(rsec_contexts.SecurityContext,
     locally_initiated = _utils.inquire_property(
         'locally_init', 'Whether this context was locally intiated')
 
-    @property  # type: ignore # https://github.com/python/mypy/issues/1362
+    @property
     @_utils.check_last_err
     def complete(self) -> bool:
         """Whether negotiation for this context has been completed"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "Cython >= 3.0.3, < 4.0.0",
+    "Cython == 3.1.3",
     "setuptools >= 40.6.0",  # Start of PEP 517 support for setuptools
 ]
 build-backend = "setuptools.build_meta"
@@ -42,17 +42,3 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = "parameterized"
 ignore_missing_imports = true
-
-[tool.tox]
-legacy_tox_ini = """
-[tox]
-envlist = py36,py37,py38
-
-[testenv]
-whitelist_externals=bash
-commands =
-    bash -c "source ./.travis/lib-verify.sh && verify::flake8"
-    python -m unittest
-
-deps = -r{toxinidir}/test-requirements.txt
-"""

--- a/setup.py
+++ b/setup.py
@@ -278,7 +278,7 @@ install_requires = [
 
 setup(
     name='gssapi',
-    version='1.9.0',
+    version='1.10.0',
     author='The Python GSSAPI Team',
     author_email='jborean93@gmail.com',
     packages=['gssapi', 'gssapi.raw', 'gssapi.raw._enum_extensions',
@@ -291,17 +291,17 @@ setup(
     long_description=long_desc,
     license='LICENSE.txt',
     url="https://github.com/pythongssapi/python-gssapi",
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
         'Intended Audience :: Developers',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Cython',

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,5 +3,5 @@ flake8
 parameterized
 k5test
 decorator
-mypy==0.971
+mypy==1.17.1
 types-decorator


### PR DESCRIPTION
Updates the build dpendencies to newer versions, sets the new minimum Python requirement to 3.9 and adds official support for Python 3.14. Also pins the build requirements to a specific Cython version to support deterministic builds.