### PR TITLE
Use the SPDX license name in `setup.py` as required by PEP-639

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -290,7 +290,8 @@ setup(
     description='Python GSSAPI Wrapper',
     long_description=long_desc,
     long_description_content_type='text/x-rst',
-    license='LICENSE.txt',
+    license='ISC',
+    license_files=['LICENCE.txt'],
     url="https://github.com/pythongssapi/python-gssapi",
     python_requires=">=3.9",
     classifiers=[


### PR DESCRIPTION
The license tag in `setup.py` is currently just the name of the license file. This confuses license checkers such as https://github.com/dhatim/python-license-check.

It also shows up weirdly on PyPI:

<img width="393" height="248" alt="image" src="https://github.com/user-attachments/assets/19134487-bb6a-454e-9128-b01ae2c26acb" />

There is a standard for this metadata field, it's [PEP 639](https://peps.python.org/pep-0639/). This commit implements it, there is no other change.